### PR TITLE
Add Dashboard tab as default landing page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,7 @@
     --background: #181a20;
     --foreground: #fff;
     --text-color: #fff;
+    --secondary-light: #2a2540;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import Navbar from "../components/Navbar";
-import SummaryChart from "@/components/SummaryChart";
+import DashboardTab from "./tabs/DashboardTab";
 import TransactionsTab from "./tabs/TransactionsTab";
 import ScheduledTransactionsTab from "./tabs/ScheduledTransactionsTab";
 import PendingTransactionsTab from "./tabs/PendingTransactionsTab";
@@ -19,7 +19,7 @@ function getTabLabel(tab: TabOption) {
   if (tab === TabOption.Transactions) return "Transactions";
   if (tab === TabOption.PendingTransactions) return "Pending Transactions";
   if (tab === TabOption.ScheduledTransactions) return "Scheduled Transactions";
-  if (tab === TabOption.Summary) return "Summary";
+  if (tab === TabOption.Dashboard) return "Dashboard";
   if (tab === TabOption.Settings) return "Settings";
   if (tab === TabOption.Trends) return "Trends";
   if (tab === TabOption.Imports) return "Imports";
@@ -27,7 +27,7 @@ function getTabLabel(tab: TabOption) {
 }
 
 export default function HomePage() {
-  const [activeTab, setActiveTab] = useState(TabOption.Transactions);
+  const [activeTab, setActiveTab] = useState(TabOption.Dashboard);
   const [isMobileNavOpen, setMobileNavOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const isMobile = useIsMobile();
@@ -51,8 +51,14 @@ export default function HomePage() {
 
   function renderTabContent(tab: TabOption) {
     switch (tab) {
-      case TabOption.Summary: {
-        return <SummaryChart />;
+      case TabOption.Dashboard: {
+        return (
+          <DashboardTab
+            onNavigateToTransactions={() =>
+              handleTabChange(TabOption.Transactions)
+            }
+          />
+        );
       }
       case TabOption.ScheduledTransactions: {
         return <ScheduledTransactionsTab />;

--- a/src/app/tabs/DashboardTab.tsx
+++ b/src/app/tabs/DashboardTab.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import {
+  useDashboardQuery,
+  useDashboardInsightsQuery,
+} from "@/hooks/useDashboardQuery";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { DashboardSkeleton } from "@/components/dashboard/DashboardSkeleton";
+import { MonthComparisonCards } from "@/components/dashboard/MonthComparisonCards";
+import { TopCategoriesChart } from "@/components/dashboard/TopCategoriesChart";
+import { MonthHighlights } from "@/components/dashboard/MonthHighlights";
+import { AiInsightsCard } from "@/components/dashboard/AiInsightsCard";
+import { RecentTransactionsQuickView } from "@/components/dashboard/RecentTransactionsQuickView";
+
+interface DashboardTabProps {
+  onNavigateToTransactions: () => void;
+}
+
+export default function DashboardTab({
+  onNavigateToTransactions,
+}: DashboardTabProps) {
+  const { data, isLoading, error } = useDashboardQuery();
+  const { data: insights, isLoading: insightsLoading } =
+    useDashboardInsightsQuery(!!data);
+  const isMobile = useIsMobile();
+
+  if (isLoading) return <DashboardSkeleton />;
+  if (error || !data) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography color="error">Failed to load dashboard</Typography>
+        <Button onClick={() => window.location.reload()} sx={{ mt: 2 }}>
+          Retry
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: { xs: 1, md: 3 } }}>
+      <MonthComparisonCards comparison={data.monthComparison} />
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: isMobile ? "column" : "row",
+          gap: 3,
+          mt: 3,
+        }}
+      >
+        <Box sx={{ flex: 2 }}>
+          <TopCategoriesChart categories={data.topCategories} />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <AiInsightsCard insights={insights} isLoading={insightsLoading} />
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: isMobile ? "column" : "row",
+          gap: 3,
+          mt: 3,
+        }}
+      >
+        <Box sx={{ flex: 1 }}>
+          <MonthHighlights
+            comparison={data.monthComparison}
+            categories={data.topCategories}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <RecentTransactionsQuickView
+            transactions={data.recentTransactions}
+            onViewAll={onNavigateToTransactions}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -149,6 +149,11 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
             }}
           >
             <Tab
+              label="Dashboard"
+              value={TabOption.Dashboard}
+              sx={getTabStyle(activeTab === TabOption.Dashboard, isMobile)}
+            />
+            <Tab
               label="Transactions"
               value={TabOption.Transactions}
               sx={getTabStyle(activeTab === TabOption.Transactions, isMobile)}
@@ -175,11 +180,6 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
               label="Imports"
               value={TabOption.Imports}
               sx={getTabStyle(activeTab === TabOption.Imports, isMobile)}
-            />
-            <Tab
-              label="Summary"
-              value={TabOption.Summary}
-              sx={getTabStyle(activeTab === TabOption.Summary, isMobile)}
             />
             <Tab
               label="Trends"
@@ -236,6 +236,11 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
             }}
           >
             <Tab
+              label="Dashboard"
+              value={TabOption.Dashboard}
+              sx={getTabStyle(activeTab === TabOption.Dashboard, isMobile)}
+            />
+            <Tab
               label="Transactions"
               value={TabOption.Transactions}
               sx={getTabStyle(activeTab === TabOption.Transactions, isMobile)}
@@ -262,11 +267,6 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
               label="Imports"
               value={TabOption.Imports}
               sx={getTabStyle(activeTab === TabOption.Imports, isMobile)}
-            />
-            <Tab
-              label="Summary"
-              value={TabOption.Summary}
-              sx={getTabStyle(activeTab === TabOption.Summary, isMobile)}
             />
             <Tab
               label="Trends"

--- a/src/components/dashboard/AiInsightsCard.tsx
+++ b/src/components/dashboard/AiInsightsCard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Skeleton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import LightbulbIcon from "@mui/icons-material/Lightbulb";
+import { DashboardInsightsResponse } from "@/types/dashboard";
+import { COLORS } from "@/utils/constants";
+
+interface Props {
+  insights: DashboardInsightsResponse | null | undefined;
+  isLoading: boolean;
+}
+
+export function AiInsightsCard({ insights, isLoading }: Props) {
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        bgcolor: "var(--background)",
+        boxShadow: 3,
+        height: "100%",
+      }}
+    >
+      <CardContent>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+          <AutoAwesomeIcon sx={{ color: COLORS.purple }} />
+          <Typography variant="h6" fontWeight={700} color={COLORS.text}>
+            AI Insights
+          </Typography>
+        </Box>
+
+        {isLoading && (
+          <Box>
+            {[1, 2, 3].map((i) => (
+              <Skeleton
+                key={i}
+                variant="text"
+                width="90%"
+                height={20}
+                sx={{ bgcolor: "var(--secondary)", mb: 1 }}
+              />
+            ))}
+          </Box>
+        )}
+
+        {!isLoading && !insights && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ fontStyle: "italic" }}
+          >
+            Insights unavailable
+          </Typography>
+        )}
+
+        {!isLoading && insights && (
+          <>
+            <List dense disablePadding>
+              {insights.unusualSpending.map((insight, idx) => (
+                <ListItem key={idx} disableGutters sx={{ py: 0.5 }}>
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    <LightbulbIcon sx={{ color: "#f39c12", fontSize: 18 }} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={insight}
+                    primaryTypographyProps={{
+                      variant: "body2",
+                      color: COLORS.text,
+                    }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+            {insights.summary && (
+              <Box
+                sx={{
+                  mt: 2,
+                  p: 1.5,
+                  borderRadius: 2,
+                  bgcolor: "var(--secondary-light)",
+                }}
+              >
+                <Typography variant="body2" color={COLORS.text}>
+                  {insights.summary}
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/AiInsightsCard.tsx
+++ b/src/components/dashboard/AiInsightsCard.tsx
@@ -57,8 +57,7 @@ export function AiInsightsCard({ insights, isLoading }: Props) {
         {!isLoading && !insights && (
           <Typography
             variant="body2"
-            color="text.secondary"
-            sx={{ fontStyle: "italic" }}
+            sx={{ color: "var(--text-secondary)", fontStyle: "italic" }}
           >
             Insights unavailable
           </Typography>

--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React from "react";
+import { Box, Paper, Skeleton } from "@mui/material";
+
+export function DashboardSkeleton() {
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* Month comparison cards skeleton */}
+      <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
+        {[1, 2, 3].map((i) => (
+          <Paper
+            key={i}
+            sx={{
+              flex: 1,
+              minWidth: 200,
+              p: 2,
+              borderRadius: 3,
+              bgcolor: "var(--background)",
+              boxShadow: 3,
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={80}
+              height={20}
+              sx={{ bgcolor: "var(--secondary)", mb: 1 }}
+            />
+            <Skeleton
+              variant="text"
+              width={120}
+              height={32}
+              sx={{ bgcolor: "var(--secondary)", mb: 1 }}
+            />
+            <Skeleton
+              variant="text"
+              width={100}
+              height={16}
+              sx={{ bgcolor: "var(--secondary)" }}
+            />
+          </Paper>
+        ))}
+      </Box>
+      {/* Chart + insights skeleton */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 3,
+          mt: 3,
+          flexDirection: { xs: "column", md: "row" },
+        }}
+      >
+        <Paper
+          sx={{
+            flex: 2,
+            p: 2,
+            borderRadius: 3,
+            bgcolor: "var(--background)",
+            boxShadow: 3,
+          }}
+        >
+          <Skeleton
+            variant="text"
+            width={160}
+            height={24}
+            sx={{ bgcolor: "var(--secondary)", mb: 2 }}
+          />
+          <Skeleton
+            variant="circular"
+            width={200}
+            height={200}
+            sx={{ bgcolor: "var(--secondary)", mx: "auto" }}
+          />
+        </Paper>
+        <Paper
+          sx={{
+            flex: 1,
+            p: 2,
+            borderRadius: 3,
+            bgcolor: "var(--background)",
+            boxShadow: 3,
+          }}
+        >
+          <Skeleton
+            variant="text"
+            width={120}
+            height={24}
+            sx={{ bgcolor: "var(--secondary)", mb: 2 }}
+          />
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              variant="text"
+              width="90%"
+              height={20}
+              sx={{ bgcolor: "var(--secondary)", mb: 1 }}
+            />
+          ))}
+        </Paper>
+      </Box>
+      {/* Bottom row skeleton */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 3,
+          mt: 3,
+          flexDirection: { xs: "column", md: "row" },
+        }}
+      >
+        <Paper
+          sx={{
+            flex: 1,
+            p: 2,
+            borderRadius: 3,
+            bgcolor: "var(--background)",
+            boxShadow: 3,
+          }}
+        >
+          <Skeleton
+            variant="text"
+            width={180}
+            height={24}
+            sx={{ bgcolor: "var(--secondary)", mb: 2 }}
+          />
+          <Skeleton
+            variant="rectangular"
+            width="100%"
+            height={80}
+            sx={{ bgcolor: "var(--secondary)", borderRadius: 1 }}
+          />
+        </Paper>
+        <Paper
+          sx={{
+            flex: 1,
+            p: 2,
+            borderRadius: 3,
+            bgcolor: "var(--background)",
+            boxShadow: 3,
+          }}
+        >
+          <Skeleton
+            variant="text"
+            width={160}
+            height={24}
+            sx={{ bgcolor: "var(--secondary)", mb: 2 }}
+          />
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton
+              key={i}
+              variant="text"
+              width="100%"
+              height={20}
+              sx={{ bgcolor: "var(--secondary)", mb: 1 }}
+            />
+          ))}
+        </Paper>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/dashboard/MonthComparisonCards.tsx
+++ b/src/components/dashboard/MonthComparisonCards.tsx
@@ -46,7 +46,7 @@ function ComparisonCard({
       }}
     >
       <CardContent>
-        <Typography variant="body2" color="text.secondary" gutterBottom>
+        <Typography variant="body2" sx={{ color: "var(--text-secondary)" }} gutterBottom>
           {title}
         </Typography>
         <Typography variant="h5" fontWeight={700} color={COLORS.text}>
@@ -57,7 +57,7 @@ function ComparisonCard({
           <Typography variant="body2" sx={{ color, fontWeight: 600 }}>
             {Math.abs(change.percentage).toFixed(1)}%
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{ color: "var(--text-secondary)" }}>
             vs last month
           </Typography>
         </Box>

--- a/src/components/dashboard/MonthComparisonCards.tsx
+++ b/src/components/dashboard/MonthComparisonCards.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import { MonthComparison, PercentageChange } from "@/types/dashboard";
+import { TrendIcon } from "@/components/trends/TrendIcon";
+import { formatNumber } from "@/utils/format";
+import { COLORS } from "@/utils/constants";
+
+interface Props {
+  comparison: MonthComparison;
+}
+
+function getChangeColor(
+  change: PercentageChange,
+  invertColors: boolean
+): string {
+  if (change.trend === "stable") return COLORS.text;
+  if (invertColors) {
+    return change.trend === "up" ? COLORS.expense : COLORS.income;
+  }
+  return change.trend === "up" ? COLORS.income : COLORS.expense;
+}
+
+function ComparisonCard({
+  title,
+  value,
+  change,
+  invertColors = false,
+}: {
+  title: string;
+  value: number;
+  change: PercentageChange;
+  invertColors?: boolean;
+}) {
+  const color = getChangeColor(change, invertColors);
+
+  return (
+    <Card
+      sx={{
+        flex: 1,
+        minWidth: 200,
+        borderRadius: 3,
+        bgcolor: "var(--background)",
+        boxShadow: 3,
+      }}
+    >
+      <CardContent>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {title}
+        </Typography>
+        <Typography variant="h5" fontWeight={700} color={COLORS.text}>
+          {formatNumber(value)}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 1 }}>
+          <TrendIcon trend={change.trend} />
+          <Typography variant="body2" sx={{ color, fontWeight: 600 }}>
+            {Math.abs(change.percentage).toFixed(1)}%
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            vs last month
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MonthComparisonCards({ comparison }: Props) {
+  return (
+    <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
+      <ComparisonCard
+        title="Income"
+        value={comparison.currentMonth.totalIncome}
+        change={comparison.incomeChange}
+      />
+      <ComparisonCard
+        title="Expenses"
+        value={comparison.currentMonth.totalExpense}
+        change={comparison.expenseChange}
+        invertColors
+      />
+      <ComparisonCard
+        title="Savings"
+        value={comparison.currentMonth.savings}
+        change={comparison.savingsChange}
+      />
+    </Box>
+  );
+}

--- a/src/components/dashboard/MonthHighlights.tsx
+++ b/src/components/dashboard/MonthHighlights.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  LinearProgress,
+} from "@mui/material";
+import { MonthComparison, TopCategory } from "@/types/dashboard";
+import { formatNumber } from "@/utils/format";
+import { COLORS } from "@/utils/constants";
+
+interface Props {
+  comparison: MonthComparison;
+  categories: TopCategory[];
+}
+
+export function MonthHighlights({ comparison, categories }: Props) {
+  const { currentMonth, previousMonth } = comparison;
+  const maxExpense = Math.max(
+    currentMonth.totalExpense,
+    previousMonth.totalExpense,
+    1
+  );
+
+  // Find biggest category increase/decrease
+  const sortedByChange = [...categories].sort(
+    (a, b) => b.change.percentage - a.change.percentage
+  );
+  const biggestIncrease = sortedByChange.find(
+    (c) => c.change.trend === "up"
+  );
+  const biggestDecrease = [...sortedByChange]
+    .reverse()
+    .find((c) => c.change.trend === "down");
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        bgcolor: "var(--background)",
+        boxShadow: 3,
+        height: "100%",
+      }}
+    >
+      <CardContent>
+        <Typography variant="h6" fontWeight={700} color={COLORS.text} mb={2}>
+          Month Highlights
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary" mb={0.5}>
+          Spending Comparison
+        </Typography>
+        <Box sx={{ mb: 2 }}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              mb: 0.5,
+            }}
+          >
+            <Typography variant="body2" color={COLORS.text}>
+              This Month
+            </Typography>
+            <Typography variant="body2" fontWeight={600} color={COLORS.text}>
+              {formatNumber(currentMonth.totalExpense)}
+            </Typography>
+          </Box>
+          <LinearProgress
+            variant="determinate"
+            value={(currentMonth.totalExpense / maxExpense) * 100}
+            sx={{
+              height: 8,
+              borderRadius: 4,
+              bgcolor: "var(--secondary-light)",
+              "& .MuiLinearProgress-bar": {
+                bgcolor: COLORS.expense,
+                borderRadius: 4,
+              },
+            }}
+          />
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              mt: 1,
+              mb: 0.5,
+            }}
+          >
+            <Typography variant="body2" color={COLORS.text}>
+              Last Month
+            </Typography>
+            <Typography variant="body2" fontWeight={600} color={COLORS.text}>
+              {formatNumber(previousMonth.totalExpense)}
+            </Typography>
+          </Box>
+          <LinearProgress
+            variant="determinate"
+            value={(previousMonth.totalExpense / maxExpense) * 100}
+            sx={{
+              height: 8,
+              borderRadius: 4,
+              bgcolor: "var(--secondary-light)",
+              "& .MuiLinearProgress-bar": {
+                bgcolor: COLORS.purple,
+                borderRadius: 4,
+              },
+            }}
+          />
+        </Box>
+
+        {biggestIncrease && (
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Biggest Increase
+            </Typography>
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              color={COLORS.expense}
+            >
+              {biggestIncrease.categoryName}: +
+              {Math.abs(biggestIncrease.change.percentage).toFixed(1)}%
+            </Typography>
+          </Box>
+        )}
+
+        {biggestDecrease && (
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Biggest Decrease
+            </Typography>
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              color={COLORS.income}
+            >
+              {biggestDecrease.categoryName}:{" "}
+              {biggestDecrease.change.percentage.toFixed(1)}%
+            </Typography>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/MonthHighlights.tsx
+++ b/src/components/dashboard/MonthHighlights.tsx
@@ -50,7 +50,7 @@ export function MonthHighlights({ comparison, categories }: Props) {
           Month Highlights
         </Typography>
 
-        <Typography variant="body2" color="text.secondary" mb={0.5}>
+        <Typography variant="body2" sx={{ color: "var(--text-secondary)", mb: 0.5 }}>
           Spending Comparison
         </Typography>
         <Box sx={{ mb: 2 }}>
@@ -113,7 +113,7 @@ export function MonthHighlights({ comparison, categories }: Props) {
 
         {biggestIncrease && (
           <Box sx={{ mb: 1 }}>
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{ color: "var(--text-secondary)" }}>
               Biggest Increase
             </Typography>
             <Typography
@@ -129,7 +129,7 @@ export function MonthHighlights({ comparison, categories }: Props) {
 
         {biggestDecrease && (
           <Box sx={{ mb: 1 }}>
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{ color: "var(--text-secondary)" }}>
               Biggest Decrease
             </Typography>
             <Typography

--- a/src/components/dashboard/RecentTransactionsQuickView.tsx
+++ b/src/components/dashboard/RecentTransactionsQuickView.tsx
@@ -43,7 +43,7 @@ export function RecentTransactionsQuickView({ transactions, onViewAll }: Props) 
         </Box>
 
         {!transactions.length && (
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{ color: "var(--text-secondary)" }}>
             No transactions yet
           </Typography>
         )}
@@ -72,7 +72,7 @@ export function RecentTransactionsQuickView({ transactions, onViewAll }: Props) 
                 <Box
                   sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.25 }}
                 >
-                  <Typography variant="caption" color="text.secondary">
+                  <Typography variant="caption" sx={{ color: "var(--text-secondary)" }}>
                     {formatTransactionDate(tx.date)}
                   </Typography>
                   <Chip

--- a/src/components/dashboard/RecentTransactionsQuickView.tsx
+++ b/src/components/dashboard/RecentTransactionsQuickView.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React from "react";
+import { Box, Card, CardContent, Typography, Button, Chip } from "@mui/material";
+import { RecentTransaction } from "@/types/dashboard";
+import { formatNumber, formatTransactionDate } from "@/utils/format";
+import { COLORS } from "@/utils/constants";
+
+interface Props {
+  transactions: RecentTransaction[];
+  onViewAll: () => void;
+}
+
+export function RecentTransactionsQuickView({ transactions, onViewAll }: Props) {
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        bgcolor: "var(--background)",
+        boxShadow: 3,
+        height: "100%",
+      }}
+    >
+      <CardContent>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+          }}
+        >
+          <Typography variant="h6" fontWeight={700} color={COLORS.text}>
+            Recent Transactions
+          </Typography>
+          <Button
+            size="small"
+            onClick={onViewAll}
+            sx={{ textTransform: "none", fontWeight: 600 }}
+          >
+            View All
+          </Button>
+        </Box>
+
+        {!transactions.length && (
+          <Typography variant="body2" color="text.secondary">
+            No transactions yet
+          </Typography>
+        )}
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          {transactions.map((tx) => (
+            <Box
+              key={tx.id}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                py: 0.5,
+                borderBottom: "1px solid var(--secondary-light)",
+              }}
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography
+                  variant="body2"
+                  fontWeight={600}
+                  color={COLORS.text}
+                  noWrap
+                >
+                  {tx.description}
+                </Typography>
+                <Box
+                  sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.25 }}
+                >
+                  <Typography variant="caption" color="text.secondary">
+                    {formatTransactionDate(tx.date)}
+                  </Typography>
+                  <Chip
+                    label={tx.categoryName}
+                    size="small"
+                    sx={{ height: 20, fontSize: 11 }}
+                  />
+                </Box>
+              </Box>
+              <Typography
+                variant="body2"
+                fontWeight={700}
+                sx={{
+                  color: tx.type === "INCOME" ? COLORS.income : COLORS.expense,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {tx.type === "INCOME" ? "+" : "-"}
+                {formatNumber(tx.value)}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/TopCategoriesChart.tsx
+++ b/src/components/dashboard/TopCategoriesChart.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import { TopCategory } from "@/types/dashboard";
+import { formatNumber } from "@/utils/format";
+import { COLORS } from "@/utils/constants";
+import { TrendIcon } from "@/components/trends/TrendIcon";
+
+const DOUGHNUT_COLORS = [
+  "#f39c12",
+  "#3498db",
+  "#e67e22",
+  "#9b59b6",
+  "#1abc9c",
+  "#e74c3c",
+  "#2ecc71",
+];
+
+interface Props {
+  categories: TopCategory[];
+}
+
+const CompactTooltip: React.FC<{
+  active?: boolean;
+  payload?: { name: string; value: number }[];
+}> = ({ active, payload }) => {
+  if (!active || !payload || !payload.length) return null;
+  const { name, value } = payload[0];
+  return (
+    <div
+      style={{
+        background: COLORS.background,
+        color: COLORS.text,
+        fontSize: 12,
+        padding: "2px 8px",
+        borderRadius: 6,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span style={{ fontWeight: 500 }}>{name}:</span> {formatNumber(value)}
+    </div>
+  );
+};
+
+export function TopCategoriesChart({ categories }: Props) {
+  if (!categories.length) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          bgcolor: "var(--background)",
+          boxShadow: 3,
+          height: "100%",
+        }}
+      >
+        <CardContent>
+          <Typography variant="h6" fontWeight={700} color={COLORS.text} mb={2}>
+            Top Categories
+          </Typography>
+          <Typography color="text.secondary">No expense data yet</Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartData = categories.map((c) => ({
+    name: c.categoryName,
+    value: c.amount,
+  }));
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        bgcolor: "var(--background)",
+        boxShadow: 3,
+        height: "100%",
+      }}
+    >
+      <CardContent>
+        <Typography variant="h6" fontWeight={700} color={COLORS.text} mb={2}>
+          Top Categories
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            alignItems: "center",
+            gap: 2,
+          }}
+        >
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                outerRadius={90}
+                innerRadius={50}
+                stroke={COLORS.background}
+                strokeWidth={2}
+              >
+                {chartData.map((_, idx) => (
+                  <Cell
+                    key={idx}
+                    fill={DOUGHNUT_COLORS[idx % DOUGHNUT_COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip content={<CompactTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+              minWidth: 200,
+            }}
+          >
+            {categories.map((cat, idx) => (
+              <Box
+                key={cat.categoryId}
+                sx={{ display: "flex", alignItems: "center", gap: 1 }}
+              >
+                <Box
+                  sx={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    bgcolor: DOUGHNUT_COLORS[idx % DOUGHNUT_COLORS.length],
+                    flexShrink: 0,
+                  }}
+                />
+                <Typography
+                  variant="body2"
+                  color={COLORS.text}
+                  sx={{ flex: 1 }}
+                >
+                  {cat.categoryName}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  fontWeight={600}
+                  color={COLORS.text}
+                >
+                  {formatNumber(cat.amount)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  ({cat.percentage.toFixed(1)}%)
+                </Typography>
+                <TrendIcon trend={cat.change.trend} />
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/TopCategoriesChart.tsx
+++ b/src/components/dashboard/TopCategoriesChart.tsx
@@ -60,7 +60,7 @@ export function TopCategoriesChart({ categories }: Props) {
           <Typography variant="h6" fontWeight={700} color={COLORS.text} mb={2}>
             Top Categories
           </Typography>
-          <Typography color="text.secondary">No expense data yet</Typography>
+          <Typography sx={{ color: "var(--text-secondary)" }}>No expense data yet</Typography>
         </CardContent>
       </Card>
     );
@@ -151,7 +151,7 @@ export function TopCategoriesChart({ categories }: Props) {
                 >
                   {formatNumber(cat.amount)}
                 </Typography>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{ color: "var(--text-secondary)" }}>
                   ({cat.percentage.toFixed(1)}%)
                 </Typography>
                 <TrendIcon trend={cat.change.trend} />

--- a/src/hooks/useDashboardQuery.ts
+++ b/src/hooks/useDashboardQuery.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchDashboard,
+  fetchDashboardInsights,
+} from "../services/dashboardService";
+
+export const dashboardKeys = {
+  all: ["dashboard"] as const,
+  overview: () => [...dashboardKeys.all, "overview"] as const,
+  insights: () => [...dashboardKeys.all, "insights"] as const,
+};
+
+export const useDashboardQuery = () => {
+  return useQuery({
+    queryKey: dashboardKeys.overview(),
+    queryFn: fetchDashboard,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const useDashboardInsightsQuery = (enabled: boolean) => {
+  return useQuery({
+    queryKey: dashboardKeys.insights(),
+    queryFn: fetchDashboardInsights,
+    staleTime: 30 * 60 * 1000,
+    enabled,
+  });
+};

--- a/src/hooks/useTransactionsQuery.ts
+++ b/src/hooks/useTransactionsQuery.ts
@@ -20,6 +20,7 @@ import {
   TransactionSummary,
 } from "../types";
 import { trendKeys } from "@/hooks/useTrendsQuery";
+import { dashboardKeys } from "@/hooks/useDashboardQuery";
 
 export const transactionKeys = {
   all: ["transactions"] as const,
@@ -56,8 +57,9 @@ export const useCreateTransactionMutation = () => {
       queryClient.invalidateQueries({
         queryKey: transactionKeys.allTransactions(),
       });
-      queryClient.invalidateQueries({ queryKey: transactionKeys.summary() }); 
+      queryClient.invalidateQueries({ queryKey: transactionKeys.summary() });
       queryClient.invalidateQueries({ queryKey: trendKeys.all });
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };
@@ -75,6 +77,7 @@ export const useUpdateTransactionMutation = () => {
       });
       queryClient.invalidateQueries({ queryKey: transactionKeys.summary() });
       queryClient.invalidateQueries({ queryKey: trendKeys.all });
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };
@@ -91,6 +94,7 @@ export const useDeleteTransactionMutation = () => {
       });
       queryClient.invalidateQueries({ queryKey: transactionKeys.summary() });
       queryClient.invalidateQueries({ queryKey: trendKeys.all });
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 };

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,15 @@
+import api from "./api";
+import {
+  DashboardResponse,
+  DashboardInsightsResponse,
+} from "@/types/dashboard";
+
+export async function fetchDashboard(): Promise<DashboardResponse> {
+  const res = await api.get("/api/dashboard");
+  return res.data;
+}
+
+export async function fetchDashboardInsights(): Promise<DashboardInsightsResponse | null> {
+  const res = await api.get("/api/dashboard/insights");
+  return res.data;
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,49 @@
+export interface DashboardResponse {
+  monthComparison: MonthComparison;
+  topCategories: TopCategory[];
+  recentTransactions: RecentTransaction[];
+}
+
+export interface DashboardInsightsResponse {
+  unusualSpending: string[];
+  summary: string;
+}
+
+export interface MonthComparison {
+  currentMonth: MonthSummary;
+  previousMonth: MonthSummary;
+  incomeChange: PercentageChange;
+  expenseChange: PercentageChange;
+  savingsChange: PercentageChange;
+}
+
+export interface MonthSummary {
+  month: string;
+  totalIncome: number;
+  totalExpense: number;
+  savings: number;
+}
+
+export interface PercentageChange {
+  amount: number;
+  percentage: number;
+  trend: "up" | "down" | "stable";
+}
+
+export interface TopCategory {
+  categoryId: string;
+  categoryName: string;
+  amount: number;
+  percentage: number;
+  previousMonthAmount: number;
+  change: PercentageChange;
+}
+
+export interface RecentTransaction {
+  id: string;
+  description: string;
+  value: number;
+  date: string;
+  type: "INCOME" | "EXPENSE";
+  categoryName: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export enum TabOption {
   Transactions = "TRANSACTIONS",
   PendingTransactions = "PENDING_TRANSACTIONS",
   ScheduledTransactions = "SCHEDULED_TRANSACTIONS",
-  Summary = "SUMMARY",
+  Dashboard = "DASHBOARD",
   Settings = "SETTINGS",
   Trends = "TRENDS",
   Imports = "IMPORTS",


### PR DESCRIPTION
## Summary
- New Dashboard tab replaces Summary as the default landing page
- Month-over-month comparison cards (income, expenses, savings with trend indicators)
- Top spending categories donut chart with recharts
- AI-powered spending insights loaded asynchronously
- Month highlights with visual spending comparison bars
- Recent transactions quick-view with "View All" navigation
- Dashboard cache invalidation on transaction mutations

## New files
- `src/types/dashboard.ts` — frontend types
- `src/services/dashboardService.ts` — API client
- `src/hooks/useDashboardQuery.ts` — React Query hooks
- 6 components in `src/components/dashboard/`
- `src/app/tabs/DashboardTab.tsx` — main tab composition

## Modified files
- `src/types/index.ts` — `Summary` → `Dashboard` in TabOption enum
- `src/app/page.tsx` — default tab changed, renders DashboardTab
- `src/components/Navbar.tsx` — Dashboard first in tab order
- `src/hooks/useTransactionsQuery.ts` — dashboard cache invalidation

## Test plan
- [ ] Dashboard loads as default tab
- [ ] Comparison cards show correct income/expense/savings with trends
- [ ] Donut chart renders top categories with legend
- [ ] AI insights load asynchronously after main dashboard
- [ ] "View All" button navigates to Transactions tab
- [ ] Mobile responsive layout (stacked columns)
- [ ] Empty state handled gracefully
- [ ] Transaction mutations invalidate dashboard cache

Generated with [Claude Code](https://claude.com/claude-code)