### PR TITLE
Fix category chip dark mode styling

### DIFF
--- a/src/components/dashboard/RecentTransactionsQuickView.tsx
+++ b/src/components/dashboard/RecentTransactionsQuickView.tsx
@@ -78,7 +78,12 @@ export function RecentTransactionsQuickView({ transactions, onViewAll }: Props) 
                   <Chip
                     label={tx.categoryName}
                     size="small"
-                    sx={{ height: 20, fontSize: 11 }}
+                    sx={{
+                      height: 20,
+                      fontSize: 11,
+                      bgcolor: "var(--secondary-light)",
+                      color: "var(--text-color)",
+                    }}
                   />
                 </Box>
               </Box>


### PR DESCRIPTION
## Summary
- Fix category Chip in RecentTransactionsQuickView using MUI default colors (black text on gray) which is unreadable in dark mode
- Use `var(--secondary-light)` for background and `var(--text-color)` for text

## Test plan
- [ ] Verify chip is readable in dark mode
- [ ] Verify chip looks good in light mode

Generated with [Claude Code](https://claude.com/claude-code)