### PR TITLE
Add batch import operations UI and auto-approve rules

### DIFF
--- a/src/app/tabs/ImportsTab.tsx
+++ b/src/app/tabs/ImportsTab.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
-import { Box, Typography, Fab, Modal, Snackbar, Alert } from "@mui/material";
+import { Box, Typography, Fab, Modal, Snackbar, Alert, IconButton } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import FileUpload from "../../components/FileUpload";
 import ImportList from "../../components/ImportList";
+import AutoApproveRuleManager from "../../components/AutoApproveRuleManager";
 
 function AddImportFab({
   onClick,
@@ -39,6 +41,7 @@ export default function ImportsTab() {
   const [isModalOpen, setModalOpen] = useState(false);
   const [expandedImport, setExpandedImport] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [rulesModalOpen, setRulesModalOpen] = useState(false);
 
   const handleUploadComplete = () => {
     setModalOpen(false);
@@ -58,6 +61,13 @@ export default function ImportsTab() {
         <Typography variant="h4" color="var(--text-color)">
           Imports
         </Typography>
+        <IconButton
+          onClick={() => setRulesModalOpen(true)}
+          title="Manage Auto-Approve Rules"
+          color="primary"
+        >
+          <AutoFixHighIcon />
+        </IconButton>
       </Box>
 
       <Box sx={{ mt: 2, flex: 1 }}>
@@ -99,6 +109,30 @@ export default function ImportsTab() {
             Import File
           </Typography>
           <FileUpload onUploadComplete={handleUploadComplete} />
+        </Box>
+      </Modal>
+
+      <Modal
+        open={rulesModalOpen}
+        onClose={() => setRulesModalOpen(false)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box
+          sx={{
+            borderRadius: 2,
+            boxShadow: 24,
+            p: 4,
+            width: isMobile ? "90%" : 700,
+            maxHeight: "90vh",
+            overflow: "auto",
+            backgroundColor: "white",
+          }}
+        >
+          <AutoApproveRuleManager />
         </Box>
       </Modal>
 

--- a/src/components/AutoApproveRuleManager.tsx
+++ b/src/components/AutoApproveRuleManager.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  MenuItem,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CategorySelect from "./CategorySelect";
+import {
+  useAutoApproveRulesQuery,
+  useCreateAutoApproveRuleMutation,
+  useUpdateAutoApproveRuleMutation,
+  useDeleteAutoApproveRuleMutation,
+} from "../hooks/useImports";
+import { AutoApproveRule } from "../types/import";
+import { TransactionType } from "../types";
+
+interface RuleFormState {
+  descriptionPattern: string;
+  categoryId: string;
+  type: TransactionType;
+}
+
+const emptyForm: RuleFormState = {
+  descriptionPattern: "",
+  categoryId: "",
+  type: "EXPENSE" as TransactionType,
+};
+
+export default function AutoApproveRuleManager() {
+  const { data: rules = [], isLoading } = useAutoApproveRulesQuery();
+  const createMutation = useCreateAutoApproveRuleMutation();
+  const updateMutation = useUpdateAutoApproveRuleMutation();
+  const deleteMutation = useDeleteAutoApproveRuleMutation();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<AutoApproveRule | null>(null);
+  const [form, setForm] = useState<RuleFormState>(emptyForm);
+
+  const handleOpen = (rule?: AutoApproveRule) => {
+    if (rule) {
+      setEditingRule(rule);
+      setForm({
+        descriptionPattern: rule.descriptionPattern,
+        categoryId: rule.categoryId,
+        type: rule.type,
+      });
+    } else {
+      setEditingRule(null);
+      setForm(emptyForm);
+    }
+    setFormOpen(true);
+  };
+
+  const handleClose = () => {
+    setFormOpen(false);
+    setEditingRule(null);
+    setForm(emptyForm);
+  };
+
+  const handleSubmit = async () => {
+    if (editingRule) {
+      await updateMutation.mutateAsync({ ruleId: editingRule.id, data: form });
+    } else {
+      await createMutation.mutateAsync(form);
+    }
+    handleClose();
+  };
+
+  const handleToggle = async (rule: AutoApproveRule) => {
+    await updateMutation.mutateAsync({
+      ruleId: rule.id,
+      data: { isActive: !rule.isActive },
+    });
+  };
+
+  const handleDelete = async (ruleId: string) => {
+    await deleteMutation.mutateAsync(ruleId);
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" p={2}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6">Auto-Approve Rules</Typography>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => handleOpen()}
+          sx={{ textTransform: "none" }}
+        >
+          Add Rule
+        </Button>
+      </Box>
+
+      {rules.length === 0 ? (
+        <Typography color="text.secondary" align="center" py={2}>
+          No auto-approve rules yet. Create one to automatically approve
+          matching imported transactions.
+        </Typography>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Pattern</TableCell>
+              <TableCell>Category</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>Active</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rules.map((rule) => (
+              <TableRow key={rule.id}>
+                <TableCell>{rule.descriptionPattern}</TableCell>
+                <TableCell>{rule.category?.name || rule.categoryId}</TableCell>
+                <TableCell>{rule.type}</TableCell>
+                <TableCell>
+                  <Switch
+                    checked={rule.isActive}
+                    onChange={() => handleToggle(rule)}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell>
+                  <IconButton size="small" onClick={() => handleOpen(rule)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={() => handleDelete(rule.id)}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={formOpen} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {editingRule ? "Edit Rule" : "Create Auto-Approve Rule"}
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+            <TextField
+              label="Description Pattern"
+              value={form.descriptionPattern}
+              onChange={(e) =>
+                setForm((prev) => ({
+                  ...prev,
+                  descriptionPattern: e.target.value,
+                }))
+              }
+              placeholder='e.g. "Wolt" matches "Wolt delivery", "WOLT*123"'
+              fullWidth
+              required
+            />
+            <CategorySelect
+              value={form.categoryId}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, categoryId: e.target.value }))
+              }
+              required
+            />
+            <TextField
+              select
+              label="Type"
+              value={form.type}
+              onChange={(e) =>
+                setForm((prev) => ({
+                  ...prev,
+                  type: e.target.value as TransactionType,
+                }))
+              }
+              fullWidth
+              required
+            >
+              <MenuItem value="EXPENSE">Expense</MenuItem>
+              <MenuItem value="INCOME">Income</MenuItem>
+            </TextField>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            disabled={
+              !form.descriptionPattern ||
+              !form.categoryId ||
+              createMutation.isPending ||
+              updateMutation.isPending
+            }
+          >
+            {editingRule ? "Update" : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/components/BatchActionToolbar.tsx
+++ b/src/components/BatchActionToolbar.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import React, { useState } from "react";
+import { Box, Button, Stack, Chip } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import SelectAllIcon from "@mui/icons-material/SelectAll";
+import DeselectIcon from "@mui/icons-material/Deselect";
+import BatchConfirmDialog from "./BatchConfirmDialog";
+import BatchProgressIndicator from "./BatchProgressIndicator";
+import {
+  useBatchActionMutation,
+  useApplyAutoApproveRulesMutation,
+} from "../hooks/useImports";
+import { BatchResult } from "../types/import";
+
+interface BatchActionToolbarProps {
+  importId: string;
+  selectedIds: string[];
+  pendingCount: number;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  hasAutoApproveRules: boolean;
+}
+
+export default function BatchActionToolbar({
+  importId,
+  selectedIds,
+  pendingCount,
+  onSelectAll,
+  onClearSelection,
+  hasAutoApproveRules,
+}: BatchActionToolbarProps) {
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean;
+    action: "approve" | "ignore";
+    scope: "all" | "selected";
+  }>({ open: false, action: "approve", scope: "all" });
+  const [batchResult, setBatchResult] = useState<BatchResult | null>(null);
+
+  const batchMutation = useBatchActionMutation(importId);
+  const autoApproveMutation = useApplyAutoApproveRulesMutation(importId);
+
+  const handleConfirm = async () => {
+    const transactionIds =
+      confirmDialog.scope === "selected" ? selectedIds : undefined;
+
+    try {
+      const result = await batchMutation.mutateAsync({
+        importId,
+        action: confirmDialog.action,
+        transactionIds,
+      });
+      setBatchResult(result);
+      onClearSelection();
+    } finally {
+      setConfirmDialog((prev) => ({ ...prev, open: false }));
+    }
+  };
+
+  const handleAutoApprove = async () => {
+    try {
+      const result = await autoApproveMutation.mutateAsync();
+      setBatchResult(result);
+    } catch {
+      // error handled by mutation
+    }
+  };
+
+  const isProcessing = batchMutation.isPending || autoApproveMutation.isPending;
+  const hasSelection = selectedIds.length > 0;
+  const confirmCount =
+    confirmDialog.scope === "selected" ? selectedIds.length : pendingCount;
+
+  if (pendingCount === 0) return null;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <BatchProgressIndicator
+        result={batchResult}
+        isLoading={isProcessing}
+        onClose={() => setBatchResult(null)}
+      />
+
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={hasSelection ? <DeselectIcon /> : <SelectAllIcon />}
+          onClick={hasSelection ? onClearSelection : onSelectAll}
+          sx={{ textTransform: "none" }}
+        >
+          {hasSelection ? "Clear" : "Select All"}
+        </Button>
+
+        {hasSelection && (
+          <Chip
+            label={`${selectedIds.length} selected`}
+            size="small"
+            color="primary"
+            variant="outlined"
+          />
+        )}
+
+        <Button
+          size="small"
+          variant="contained"
+          color="success"
+          startIcon={<CheckIcon />}
+          onClick={() =>
+            setConfirmDialog({ open: true, action: "approve", scope: "all" })
+          }
+          disabled={isProcessing}
+          sx={{ textTransform: "none" }}
+        >
+          Approve All ({pendingCount})
+        </Button>
+
+        {hasSelection && (
+          <Button
+            size="small"
+            variant="contained"
+            color="success"
+            startIcon={<CheckIcon />}
+            onClick={() =>
+              setConfirmDialog({
+                open: true,
+                action: "approve",
+                scope: "selected",
+              })
+            }
+            disabled={isProcessing}
+            sx={{ textTransform: "none" }}
+          >
+            Approve Selected ({selectedIds.length})
+          </Button>
+        )}
+
+        <Button
+          size="small"
+          variant="contained"
+          color="warning"
+          startIcon={<CloseIcon />}
+          onClick={() =>
+            setConfirmDialog({ open: true, action: "ignore", scope: "all" })
+          }
+          disabled={isProcessing}
+          sx={{ textTransform: "none" }}
+        >
+          Ignore All ({pendingCount})
+        </Button>
+
+        {hasSelection && (
+          <Button
+            size="small"
+            variant="contained"
+            color="warning"
+            startIcon={<CloseIcon />}
+            onClick={() =>
+              setConfirmDialog({
+                open: true,
+                action: "ignore",
+                scope: "selected",
+              })
+            }
+            disabled={isProcessing}
+            sx={{ textTransform: "none" }}
+          >
+            Ignore Selected ({selectedIds.length})
+          </Button>
+        )}
+
+        {hasAutoApproveRules && (
+          <Button
+            size="small"
+            variant="contained"
+            color="info"
+            startIcon={<AutoFixHighIcon />}
+            onClick={handleAutoApprove}
+            disabled={isProcessing}
+            sx={{ textTransform: "none" }}
+          >
+            Auto-Approve Rules
+          </Button>
+        )}
+      </Stack>
+
+      <BatchConfirmDialog
+        open={confirmDialog.open}
+        onClose={() => setConfirmDialog((prev) => ({ ...prev, open: false }))}
+        onConfirm={handleConfirm}
+        action={confirmDialog.action}
+        count={confirmCount}
+        isLoading={batchMutation.isPending}
+      />
+    </Box>
+  );
+}

--- a/src/components/BatchActionToolbar.tsx
+++ b/src/components/BatchActionToolbar.tsx
@@ -114,7 +114,7 @@ export default function BatchActionToolbar({
           disabled={isProcessing}
           sx={{ textTransform: "none" }}
         >
-          Approve All ({pendingCount})
+          Approve/Merge All ({pendingCount})
         </Button>
 
         {hasSelection && (
@@ -133,7 +133,7 @@ export default function BatchActionToolbar({
             disabled={isProcessing}
             sx={{ textTransform: "none" }}
           >
-            Approve Selected ({selectedIds.length})
+            Approve/Merge Selected ({selectedIds.length})
           </Button>
         )}
 

--- a/src/components/BatchConfirmDialog.tsx
+++ b/src/components/BatchConfirmDialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  CircularProgress,
+} from "@mui/material";
+
+interface BatchConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  action: "approve" | "ignore";
+  count: number;
+  isLoading: boolean;
+}
+
+export default function BatchConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  action,
+  count,
+  isLoading,
+}: BatchConfirmDialogProps) {
+  const actionLabel = action === "approve" ? "approve" : "ignore";
+
+  return (
+    <Dialog open={open} onClose={isLoading ? undefined : onClose}>
+      <DialogTitle>Confirm Batch {action === "approve" ? "Approve" : "Ignore"}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Are you sure you want to {actionLabel} {count} transaction
+          {count !== 1 ? "s" : ""}?
+          {action === "approve" &&
+            " Each transaction will be created as a real transaction record."}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          variant="contained"
+          color={action === "approve" ? "success" : "warning"}
+          disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size={16} /> : undefined}
+        >
+          {isLoading ? "Processing..." : `${action === "approve" ? "Approve" : "Ignore"} ${count}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/BatchConfirmDialog.tsx
+++ b/src/components/BatchConfirmDialog.tsx
@@ -32,13 +32,13 @@ export default function BatchConfirmDialog({
 
   return (
     <Dialog open={open} onClose={isLoading ? undefined : onClose}>
-      <DialogTitle>Confirm Batch {action === "approve" ? "Approve" : "Ignore"}</DialogTitle>
+      <DialogTitle>Confirm Batch {action === "approve" ? "Approve/Merge" : "Ignore"}</DialogTitle>
       <DialogContent>
         <DialogContentText>
           Are you sure you want to {actionLabel} {count} transaction
           {count !== 1 ? "s" : ""}?
           {action === "approve" &&
-            " Each transaction will be created as a real transaction record."}
+            " Transactions with a match will be merged; others will be created as new records."}
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/src/components/BatchProgressIndicator.tsx
+++ b/src/components/BatchProgressIndicator.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Alert,
+  Box,
+  Collapse,
+  IconButton,
+  LinearProgress,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CloseIcon from "@mui/icons-material/Close";
+import { BatchResult } from "../types/import";
+
+interface BatchProgressIndicatorProps {
+  result: BatchResult | null;
+  isLoading: boolean;
+  onClose: () => void;
+}
+
+export default function BatchProgressIndicator({
+  result,
+  isLoading,
+  onClose,
+}: BatchProgressIndicatorProps) {
+  const [showErrors, setShowErrors] = useState(false);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          Processing batch operation...
+        </Typography>
+        <LinearProgress />
+      </Box>
+    );
+  }
+
+  if (!result) return null;
+
+  const severity =
+    result.failed === 0
+      ? "success"
+      : result.succeeded === 0
+        ? "error"
+        : "warning";
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Alert
+        severity={severity}
+        action={
+          <IconButton size="small" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        }
+      >
+        <Typography variant="body2">
+          {result.succeeded} of {result.total} transactions processed
+          successfully.
+          {result.failed > 0 && ` ${result.failed} failed.`}
+        </Typography>
+        {result.errors.length > 0 && (
+          <>
+            <IconButton
+              size="small"
+              onClick={() => setShowErrors(!showErrors)}
+              sx={{ ml: 1 }}
+            >
+              <ExpandMoreIcon
+                sx={{
+                  transform: showErrors ? "rotate(180deg)" : "none",
+                  transition: "transform 0.2s",
+                }}
+              />
+            </IconButton>
+            <Collapse in={showErrors}>
+              <Box sx={{ mt: 1 }}>
+                {result.errors.map((err, i) => (
+                  <Typography key={i} variant="caption" display="block">
+                    {err.id}: {err.error}
+                  </Typography>
+                ))}
+              </Box>
+            </Collapse>
+          </>
+        )}
+      </Alert>
+    </Box>
+  );
+}

--- a/src/components/ImportedTransactionList.tsx
+++ b/src/components/ImportedTransactionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import {
   Box,
   Table,
@@ -8,6 +8,7 @@ import {
   TableCell,
   Typography,
   Button,
+  Checkbox,
   Chip,
   CircularProgress,
   Stack,
@@ -24,6 +25,7 @@ import {
   useMergeImportedTransactionMutation,
   useDeleteImportedTransactionMutation,
   useIgnoreImportedTransactionMutation,
+  useAutoApproveRulesQuery,
 } from "../hooks/useImports";
 import { formatDate } from "../utils/dateUtils";
 import {
@@ -31,6 +33,7 @@ import {
   ImportedTransaction,
 } from "../types/import";
 import TransactionForm from "./TransactionForm";
+import BatchActionToolbar from "./BatchActionToolbar";
 import { CreateTransactionInput } from "../types";
 
 interface ImportedTransactionListProps {
@@ -55,12 +58,46 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
   const [pendingOperations, setPendingOperations] = useState<
     Record<string, string>
   >({});
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const { data: autoApproveRules = [] } = useAutoApproveRulesQuery();
 
   const formatAmount = (value: number) => {
     return new Intl.NumberFormat("he-IL", {
       style: "currency",
       currency: "ILS",
     }).format(value);
+  };
+
+  const activeTransactions = useMemo(
+    () => transactions.filter((t) => !t.deleted),
+    [transactions]
+  );
+  const pendingTransactions = useMemo(
+    () =>
+      activeTransactions.filter(
+        (t) => t.status === ImportedTransactionStatus.PENDING
+      ),
+    [activeTransactions]
+  );
+
+  const handleSelectAll = () => {
+    setSelectedIds(new Set(pendingTransactions.map((t) => t.id)));
+  };
+
+  const handleClearSelection = () => {
+    setSelectedIds(new Set());
+  };
+
+  const handleToggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   };
 
   const handleMerge = async (transactionId: string) => {
@@ -163,8 +200,6 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
     );
   }
 
-  const activeTransactions = transactions.filter((t) => !t.deleted);
-
   if (!activeTransactions.length) {
     return (
       <Typography color="var(--text-color)" align="center" py={2}>
@@ -175,9 +210,32 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
 
   return (
     <>
+      <BatchActionToolbar
+        importId={importId}
+        selectedIds={Array.from(selectedIds)}
+        pendingCount={pendingTransactions.length}
+        onSelectAll={handleSelectAll}
+        onClearSelection={handleClearSelection}
+        hasAutoApproveRules={autoApproveRules.length > 0}
+      />
       <Table size="small">
         <TableHead>
           <TableRow>
+            <TableCell padding="checkbox">
+              <Checkbox
+                indeterminate={
+                  selectedIds.size > 0 &&
+                  selectedIds.size < pendingTransactions.length
+                }
+                checked={
+                  pendingTransactions.length > 0 &&
+                  selectedIds.size === pendingTransactions.length
+                }
+                onChange={(e) =>
+                  e.target.checked ? handleSelectAll() : handleClearSelection()
+                }
+              />
+            </TableCell>
             <TableCell>Transaction Details</TableCell>
             <TableCell>Matching Transaction</TableCell>
             <TableCell>Status</TableCell>
@@ -186,7 +244,15 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
         </TableHead>
         <TableBody>
           {activeTransactions.map((transaction) => (
-            <TableRow key={transaction.id}>
+            <TableRow key={transaction.id} selected={selectedIds.has(transaction.id)}>
+              <TableCell padding="checkbox">
+                {transaction.status === ImportedTransactionStatus.PENDING ? (
+                  <Checkbox
+                    checked={selectedIds.has(transaction.id)}
+                    onChange={() => handleToggleSelect(transaction.id)}
+                  />
+                ) : null}
+              </TableCell>
               <TableCell>
                 <Box>
                   <Typography variant="body2">

--- a/src/hooks/useImports.ts
+++ b/src/hooks/useImports.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { importService } from "../services/importService";
-import { Import } from "../types/import";
+import { Import, BatchActionRequest, AutoApproveRule } from "../types/import";
 import { pendingTransactionKeys } from "@/hooks/usePendingTransactionsQuery";
 import { transactionKeys } from "@/hooks/useTransactionsQuery";
 import { trendKeys } from "@/hooks/useTrendsQuery";
@@ -110,6 +110,95 @@ export const useDeleteImportedTransactionMutation = (importId: string) => {
       queryClient.invalidateQueries({
         queryKey: ["imported-transactions", importId],
       });
+    },
+  });
+};
+
+export const useBatchActionMutation = (importId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: BatchActionRequest) =>
+      importService.batchAction(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["imported-transactions", importId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: pendingTransactionKeys.lists(),
+      });
+      queryClient.invalidateQueries({ queryKey: transactionKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: transactionKeys.allTransactions(),
+      });
+      queryClient.invalidateQueries({ queryKey: transactionKeys.summary() });
+      queryClient.invalidateQueries({ queryKey: trendKeys.all });
+    },
+  });
+};
+
+export const useApplyAutoApproveRulesMutation = (importId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => importService.applyAutoApproveRules(importId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["imported-transactions", importId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: pendingTransactionKeys.lists(),
+      });
+      queryClient.invalidateQueries({ queryKey: transactionKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: transactionKeys.allTransactions(),
+      });
+      queryClient.invalidateQueries({ queryKey: transactionKeys.summary() });
+      queryClient.invalidateQueries({ queryKey: trendKeys.all });
+    },
+  });
+};
+
+export const useAutoApproveRulesQuery = () => {
+  return useQuery<AutoApproveRule[]>({
+    queryKey: ["auto-approve-rules"],
+    queryFn: () => importService.getAutoApproveRules(),
+  });
+};
+
+export const useCreateAutoApproveRuleMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (
+      data: Pick<AutoApproveRule, "descriptionPattern" | "categoryId" | "type">
+    ) => importService.createAutoApproveRule(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["auto-approve-rules"] });
+    },
+  });
+};
+
+export const useUpdateAutoApproveRuleMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      ruleId,
+      data,
+    }: {
+      ruleId: string;
+      data: Partial<AutoApproveRule>;
+    }) => importService.updateAutoApproveRule(ruleId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["auto-approve-rules"] });
+    },
+  });
+};
+
+export const useDeleteAutoApproveRuleMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (ruleId: string) =>
+      importService.deleteAutoApproveRule(ruleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["auto-approve-rules"] });
     },
   });
 };

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -1,5 +1,11 @@
 import api from "@/services/api";
-import { Import, ImportedTransaction } from "../types/import";
+import {
+  Import,
+  ImportedTransaction,
+  BatchActionRequest,
+  BatchResult,
+  AutoApproveRule,
+} from "../types/import";
 import { CreateTransactionInput } from "../types";
 
 class ImportService {
@@ -48,6 +54,45 @@ class ImportService {
 
   async deleteImportedTransaction(transactionId: string): Promise<void> {
     await api.delete(`/api/imports/transactions/${transactionId}`);
+  }
+
+  async batchAction(request: BatchActionRequest): Promise<BatchResult> {
+    const response = await api.post("/api/imports/batch-action", request);
+    return response.data;
+  }
+
+  async applyAutoApproveRules(importId: string): Promise<BatchResult> {
+    const response = await api.post(
+      `/api/imports/${importId}/apply-auto-approve-rules`
+    );
+    return response.data;
+  }
+
+  async getAutoApproveRules(): Promise<AutoApproveRule[]> {
+    const response = await api.get("/api/imports/auto-approve-rules");
+    return response.data;
+  }
+
+  async createAutoApproveRule(
+    data: Pick<AutoApproveRule, "descriptionPattern" | "categoryId" | "type">
+  ): Promise<AutoApproveRule> {
+    const response = await api.post("/api/imports/auto-approve-rules", data);
+    return response.data;
+  }
+
+  async updateAutoApproveRule(
+    ruleId: string,
+    data: Partial<AutoApproveRule>
+  ): Promise<AutoApproveRule> {
+    const response = await api.put(
+      `/api/imports/auto-approve-rules/${ruleId}`,
+      data
+    );
+    return response.data;
+  }
+
+  async deleteAutoApproveRule(ruleId: string): Promise<void> {
+    await api.delete(`/api/imports/auto-approve-rules/${ruleId}`);
   }
 }
 

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -64,3 +64,27 @@ export interface ImportedTransaction {
   rawData: unknown;
   deleted?: boolean;
 }
+
+export interface BatchActionRequest {
+  importId: string;
+  transactionIds?: string[];
+  action: 'approve' | 'ignore';
+}
+
+export interface BatchResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+  errors: Array<{ id: string; error: string }>;
+}
+
+export interface AutoApproveRule {
+  id: string;
+  descriptionPattern: string;
+  categoryId: string;
+  type: TransactionType;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  category?: { id: string; name: string };
+}


### PR DESCRIPTION
## Summary
- Add batch action toolbar with Approve All/Selected and Ignore All/Selected buttons
- Add multi-select checkboxes on imported transaction rows (pending only)
- Add confirmation dialogs and progress/result indicators for batch operations
- Add AutoApproveRuleManager component for creating/editing/deleting pattern-based rules
- Add auto-approve rules management button in ImportsTab header

## Test plan
- [ ] Verify batch approve/ignore all works with confirmation dialog
- [ ] Verify multi-select checkboxes appear only on pending transactions
- [ ] Verify "Approve Selected" / "Ignore Selected" only appear when items are selected
- [ ] Test auto-approve rule CRUD in the rules management modal
- [ ] Verify progress indicator shows loading state and result summary
- [ ] Verify query invalidation refreshes transaction lists after batch operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)