### PR TITLE
UI/UX improvements with import filtering and soft delete

### DIFF
--- a/src/app/tabs/DashboardTab.tsx
+++ b/src/app/tabs/DashboardTab.tsx
@@ -36,8 +36,8 @@ export default function DashboardTab({
 
   const handleCreateSuccess = async (data: CreateTransactionInput) => {
     try {
-      const newId = await createMutation.mutateAsync(data);
-      return newId;
+      const result = await createMutation.mutateAsync(data);
+      return result.id;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create transaction");
     }

--- a/src/app/tabs/TransactionsTab.tsx
+++ b/src/app/tabs/TransactionsTab.tsx
@@ -22,6 +22,8 @@ import {
   useTransactionsSummaryQuery,
 } from "../../hooks/useTransactionsQuery";
 import IncomeExpensePieChart from "../../components/IncomeExpensePieChart";
+import CategoryConfirmationSnackbar from "../../components/CategoryConfirmationSnackbar";
+import { CreateTransactionResponse } from "../../services/transactions";
 import dayjs from "dayjs";
 
 function TransactionTableArea({
@@ -93,6 +95,11 @@ export default function TransactionsTab() {
     ...getDefaultFilters(),
   });
   const [error, setError] = useState<string | null>(null);
+  const [categoryConfirmation, setCategoryConfirmation] = useState<{
+    transactionId: string;
+    description: string;
+    suggestedCategory: { id: string; name: string };
+  } | null>(null);
 
   const { data: transactions = [], isLoading: loading } =
     useTransactionsQuery(filters);
@@ -126,8 +133,16 @@ export default function TransactionsTab() {
 
   const handleCreateSuccess = async (data: CreateTransactionInput) => {
     try {
-      const newId = await createMutation.mutateAsync(data);
-      return newId;
+      const result: CreateTransactionResponse =
+        await createMutation.mutateAsync(data);
+      if (result.suggestedCategory) {
+        setCategoryConfirmation({
+          transactionId: result.id,
+          description: data.description,
+          suggestedCategory: result.suggestedCategory,
+        });
+      }
+      return result.id;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create transaction");
     }
@@ -232,6 +247,16 @@ export default function TransactionsTab() {
         onApply={handleApplyFilters}
         initialFilters={filters}
       />
+
+      {categoryConfirmation && (
+        <CategoryConfirmationSnackbar
+          open={!!categoryConfirmation}
+          transactionId={categoryConfirmation.transactionId}
+          description={categoryConfirmation.description}
+          suggestedCategory={categoryConfirmation.suggestedCategory}
+          onClose={() => setCategoryConfirmation(null)}
+        />
+      )}
 
       <Snackbar
         open={!!error}

--- a/src/components/CategoryConfirmationSnackbar.tsx
+++ b/src/components/CategoryConfirmationSnackbar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Snackbar,
+  Alert,
+  Button,
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
+import CategorySelect from "./CategorySelect";
+import { useUpdateTransactionMutation } from "../hooks/useTransactionsQuery";
+import { UpdateTransactionInput } from "../types";
+
+interface CategoryConfirmationSnackbarProps {
+  open: boolean;
+  transactionId: string;
+  description: string;
+  suggestedCategory: { id: string; name: string };
+  onClose: () => void;
+}
+
+export default function CategoryConfirmationSnackbar({
+  open,
+  transactionId,
+  description,
+  suggestedCategory,
+  onClose,
+}: CategoryConfirmationSnackbarProps) {
+  const [changingCategory, setChangingCategory] = useState(false);
+  const [selectedCategoryId, setSelectedCategoryId] = useState(
+    suggestedCategory.id
+  );
+  const updateMutation = useUpdateTransactionMutation();
+
+  const handleChange = () => {
+    setSelectedCategoryId(suggestedCategory.id);
+    setChangingCategory(true);
+  };
+
+  const handleSave = async () => {
+    if (selectedCategoryId && selectedCategoryId !== suggestedCategory.id) {
+      await updateMutation.mutateAsync({
+        id: transactionId,
+        data: { categoryId: selectedCategoryId } as UpdateTransactionInput,
+      });
+    }
+    setChangingCategory(false);
+    onClose();
+  };
+
+  const handleDialogClose = () => {
+    setChangingCategory(false);
+  };
+
+  const truncatedDescription =
+    description.length > 30 ? description.slice(0, 30) + "..." : description;
+
+  return (
+    <>
+      <Snackbar
+        open={open && !changingCategory}
+        autoHideDuration={10000}
+        onClose={onClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          severity="info"
+          variant="filled"
+          onClose={onClose}
+          action={
+            <Button color="inherit" size="small" onClick={handleChange}>
+              Change
+            </Button>
+          }
+          sx={{ width: "100%", alignItems: "center" }}
+        >
+          <Typography variant="body2">
+            Category for &quot;{truncatedDescription}&quot;:{" "}
+            <strong>{suggestedCategory.name}</strong>
+          </Typography>
+        </Alert>
+      </Snackbar>
+
+      <Dialog
+        open={changingCategory}
+        onClose={handleDialogClose}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Change Category</DialogTitle>
+        <DialogContent>
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              &quot;{description}&quot;
+            </Typography>
+            <CategorySelect
+              value={selectedCategoryId}
+              onChange={setSelectedCategoryId}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDialogClose} variant="outlined">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            color="primary"
+            disabled={updateMutation.isPending}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/ImportList.tsx
+++ b/src/components/ImportList.tsx
@@ -1,20 +1,43 @@
 "use client";
 
-import React from "react";
-import { Box, Typography, Chip, Collapse } from "@mui/material";
+import React, { useState, useMemo } from "react";
+import {
+  Box,
+  Typography,
+  Chip,
+  Collapse,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Stack,
+} from "@mui/material";
 import {
   KeyboardArrowDown,
   KeyboardArrowUp,
   CheckCircle,
   Cancel,
+  Delete,
+  ArrowUpward,
+  ArrowDownward,
 } from "@mui/icons-material";
 import { Import, ImportStatus } from "../types/import";
-import { useImportsQuery } from "../hooks/useImports";
+import { useImportsQuery, useDeleteImportMutation } from "../hooks/useImports";
 import ImportedTransactionList from "./ImportedTransactionList";
 import { formatDate } from "../utils/dateUtils";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import EmptyState from "./EmptyState";
 import ImportListSkeleton from "./ImportListSkeleton";
+
+type SortField = "createdAt" | "paymentMonth" | "status";
+type SortDirection = "asc" | "desc";
 
 function getStatusColor(status: ImportStatus) {
   switch (status) {
@@ -29,14 +52,33 @@ function getStatusColor(status: ImportStatus) {
   }
 }
 
+function SortIndicator({
+  field,
+  sortField,
+  sortDirection,
+}: {
+  field: SortField;
+  sortField: SortField;
+  sortDirection: SortDirection;
+}) {
+  if (field !== sortField) return null;
+  return sortDirection === "asc" ? (
+    <ArrowUpward sx={{ fontSize: 16, ml: 0.5, verticalAlign: "middle" }} />
+  ) : (
+    <ArrowDownward sx={{ fontSize: 16, ml: 0.5, verticalAlign: "middle" }} />
+  );
+}
+
 function ImportRowMobile({
   importItem,
   onImportClick,
   isExpanded,
+  onDeleteClick,
 }: {
   importItem: Import;
   onImportClick: (id: string) => void;
   isExpanded: boolean;
+  onDeleteClick: (importItem: Import) => void;
 }) {
   return (
     <tr
@@ -67,6 +109,16 @@ function ImportRowMobile({
             </div>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <IconButton
+              size="small"
+              color="error"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteClick(importItem);
+              }}
+            >
+              <Delete fontSize="small" />
+            </IconButton>
             {importItem.isVerified ? (
               <CheckCircle color="success" fontSize="small" />
             ) : (
@@ -89,10 +141,12 @@ function ImportRowDesktop({
   importItem,
   onImportClick,
   isExpanded,
+  onDeleteClick,
 }: {
   importItem: Import;
   onImportClick: (id: string) => void;
   isExpanded: boolean;
+  onDeleteClick: (importItem: Import) => void;
 }) {
   return (
     <tr
@@ -121,6 +175,18 @@ function ImportRowDesktop({
       </td>
       <td>{formatDate(importItem.createdAt, true)}</td>
       <td>{formatDate(importItem.updatedAt, true)}</td>
+      <td style={{ textAlign: "center" }}>
+        <IconButton
+          size="small"
+          color="error"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteClick(importItem);
+          }}
+        >
+          <Delete fontSize="small" />
+        </IconButton>
+      </td>
     </tr>
   );
 }
@@ -135,7 +201,86 @@ export default function ImportList({
   expandedImportId,
 }: ImportListProps) {
   const { data: imports = [], isLoading } = useImportsQuery();
+  const deleteImportMutation = useDeleteImportMutation();
   const isMobile = useIsMobile();
+
+  // Delete confirmation state
+  const [deleteTarget, setDeleteTarget] = useState<Import | null>(null);
+
+  // Filter state
+  const [statusFilter, setStatusFilter] = useState<string>("ALL");
+  const [paymentMonthFilter, setPaymentMonthFilter] = useState<string>("ALL");
+  const [cardFilter, setCardFilter] = useState<string>("ALL");
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField>("createdAt");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  // Derive unique filter options from data
+  const filterOptions = useMemo(() => {
+    const paymentMonths = Array.from(
+      new Set(imports.map((i) => i.paymentMonth).filter(Boolean))
+    ).sort() as string[];
+    const cards = Array.from(
+      new Set(
+        imports.map((i) => i.creditCardLastFourDigits).filter(Boolean)
+      )
+    ).sort() as string[];
+    return { paymentMonths, cards };
+  }, [imports]);
+
+  // Filtered + sorted list
+  const filteredImports = useMemo(() => {
+    let result = imports.filter((imp) => {
+      if (statusFilter !== "ALL" && imp.status !== statusFilter) return false;
+      if (
+        paymentMonthFilter !== "ALL" &&
+        imp.paymentMonth !== paymentMonthFilter
+      )
+        return false;
+      if (
+        cardFilter !== "ALL" &&
+        imp.creditCardLastFourDigits !== cardFilter
+      )
+        return false;
+      return true;
+    });
+
+    result = [...result].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case "createdAt":
+          cmp =
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
+        case "paymentMonth":
+          cmp = (a.paymentMonth || "").localeCompare(b.paymentMonth || "");
+          break;
+        case "status":
+          cmp = a.status.localeCompare(b.status);
+          break;
+      }
+      return sortDirection === "asc" ? cmp : -cmp;
+    });
+
+    return result;
+  }, [imports, statusFilter, paymentMonthFilter, cardFilter, sortField, sortDirection]);
+
+  const handleSortClick = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortDirection("asc");
+    }
+  };
+
+  const handleDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteImportMutation.mutate(deleteTarget.id);
+      setDeleteTarget(null);
+    }
+  };
 
   if (isLoading) {
     return <ImportListSkeleton rows={6} />;
@@ -145,97 +290,235 @@ export default function ImportList({
     return <EmptyState message="No imports found." />;
   }
 
+  const filterBar = (
+    <Stack
+      direction={isMobile ? "column" : "row"}
+      spacing={1.5}
+      sx={{ p: 2 }}
+    >
+      <FormControl size="small" sx={{ minWidth: 130 }}>
+        <InputLabel>Status</InputLabel>
+        <Select
+          value={statusFilter}
+          label="Status"
+          onChange={(e) => setStatusFilter(e.target.value)}
+        >
+          <MenuItem value="ALL">All</MenuItem>
+          {Object.values(ImportStatus).map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small" sx={{ minWidth: 150 }}>
+        <InputLabel>Payment Month</InputLabel>
+        <Select
+          value={paymentMonthFilter}
+          label="Payment Month"
+          onChange={(e) => setPaymentMonthFilter(e.target.value)}
+        >
+          <MenuItem value="ALL">All</MenuItem>
+          {filterOptions.paymentMonths.map((m) => (
+            <MenuItem key={m} value={m}>
+              {m}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small" sx={{ minWidth: 140 }}>
+        <InputLabel>Card (Last 4)</InputLabel>
+        <Select
+          value={cardFilter}
+          label="Card (Last 4)"
+          onChange={(e) => setCardFilter(e.target.value)}
+        >
+          <MenuItem value="ALL">All</MenuItem>
+          {filterOptions.cards.map((c) => (
+            <MenuItem key={c} value={c}>
+              {c}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Stack>
+  );
+
+  const deleteDialog = (
+    <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+      <DialogTitle>Delete Import</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Are you sure you want to delete the import &quot;
+          {deleteTarget?.originalFileName}&quot;? This action cannot be undone.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={handleDeleteConfirm}
+          disabled={deleteImportMutation.isPending}
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+
   if (isMobile) {
     return (
-      <div className="card-accent" style={{ padding: 0 }}>
-        <table
-          className="table"
-          style={{
-            borderCollapse: "separate",
-            borderSpacing: 0,
-            width: "100%",
-          }}
-        >
-          <tbody>
-            {imports.map((importItem) => (
-              <React.Fragment key={importItem.id}>
-                <ImportRowMobile
-                  importItem={importItem}
-                  onImportClick={onImportClick}
-                  isExpanded={expandedImportId === importItem.id}
-                />
-                {importItem.status === ImportStatus.COMPLETED && (
-                  <tr>
-                    <td style={{ padding: 0 }}>
-                      <Collapse
-                        in={expandedImportId === importItem.id}
-                        timeout="auto"
-                        unmountOnExit
-                      >
-                        <Box sx={{ py: 2, px: 1 }}>
-                          <ImportedTransactionList importId={importItem.id} />
-                        </Box>
-                      </Collapse>
-                    </td>
-                  </tr>
-                )}
-              </React.Fragment>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <>
+        {filterBar}
+        <div className="card-accent" style={{ padding: 0 }}>
+          <table
+            className="table"
+            style={{
+              borderCollapse: "separate",
+              borderSpacing: 0,
+              width: "100%",
+            }}
+          >
+            <tbody>
+              {filteredImports.map((importItem) => (
+                <React.Fragment key={importItem.id}>
+                  <ImportRowMobile
+                    importItem={importItem}
+                    onImportClick={onImportClick}
+                    isExpanded={expandedImportId === importItem.id}
+                    onDeleteClick={setDeleteTarget}
+                  />
+                  {importItem.status === ImportStatus.COMPLETED && (
+                    <tr>
+                      <td style={{ padding: 0 }}>
+                        <Collapse
+                          in={expandedImportId === importItem.id}
+                          timeout="auto"
+                          unmountOnExit
+                        >
+                          <Box sx={{ py: 2, px: 1 }}>
+                            <ImportedTransactionList
+                              importId={importItem.id}
+                            />
+                          </Box>
+                        </Collapse>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              ))}
+              {filteredImports.length === 0 && (
+                <tr>
+                  <td style={{ padding: "2rem", textAlign: "center" }}>
+                    <Typography color="text.secondary">
+                      No imports match the selected filters.
+                    </Typography>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        {deleteDialog}
+      </>
     );
   }
 
   return (
-    <div className="card-accent" style={{ padding: 0 }}>
-      <table className="table">
-        <thead>
-          <tr>
-            <th style={{ width: 48 }}></th>
-            <th>Card (Last 4)</th>
-            <th>Payment Month</th>
-            <th>File Name</th>
-            <th>Status</th>
-            <th>Verified</th>
-            <th>Created At</th>
-            <th>Updated At</th>
-          </tr>
-        </thead>
-        <tbody>
-          {imports.map((importItem) => (
-            <React.Fragment key={importItem.id}>
-              <ImportRowDesktop
-                importItem={importItem}
-                onImportClick={onImportClick}
-                isExpanded={expandedImportId === importItem.id}
-              />
+    <>
+      {filterBar}
+      <div className="card-accent" style={{ padding: 0 }}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th style={{ width: 48 }}></th>
+              <th>Card (Last 4)</th>
+              <th
+                style={{ cursor: "pointer" }}
+                onClick={() => handleSortClick("paymentMonth")}
+              >
+                Payment Month
+                <SortIndicator
+                  field="paymentMonth"
+                  sortField={sortField}
+                  sortDirection={sortDirection}
+                />
+              </th>
+              <th>File Name</th>
+              <th
+                style={{ cursor: "pointer" }}
+                onClick={() => handleSortClick("status")}
+              >
+                Status
+                <SortIndicator
+                  field="status"
+                  sortField={sortField}
+                  sortDirection={sortDirection}
+                />
+              </th>
+              <th>Verified</th>
+              <th
+                style={{ cursor: "pointer" }}
+                onClick={() => handleSortClick("createdAt")}
+              >
+                Created At
+                <SortIndicator
+                  field="createdAt"
+                  sortField={sortField}
+                  sortDirection={sortDirection}
+                />
+              </th>
+              <th>Updated At</th>
+              <th style={{ width: 60 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredImports.map((importItem) => (
+              <React.Fragment key={importItem.id}>
+                <ImportRowDesktop
+                  importItem={importItem}
+                  onImportClick={onImportClick}
+                  isExpanded={expandedImportId === importItem.id}
+                  onDeleteClick={setDeleteTarget}
+                />
+                <tr>
+                  <td colSpan={9} style={{ padding: 0 }}>
+                    <Collapse
+                      in={expandedImportId === importItem.id}
+                      timeout="auto"
+                      unmountOnExit
+                    >
+                      <Box sx={{ py: 2, px: 3 }}>
+                        <ImportedTransactionList importId={importItem.id} />
+                        {importItem.status === ImportStatus.FAILED && (
+                          <Typography
+                            color="error"
+                            variant="body2"
+                            sx={{ mt: 2 }}
+                          >
+                            Error: {importItem.error}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Collapse>
+                  </td>
+                </tr>
+              </React.Fragment>
+            ))}
+            {filteredImports.length === 0 && (
               <tr>
-                <td colSpan={8} style={{ padding: 0 }}>
-                  <Collapse
-                    in={expandedImportId === importItem.id}
-                    timeout="auto"
-                    unmountOnExit
-                  >
-                    <Box sx={{ py: 2, px: 3 }}>
-                      <ImportedTransactionList importId={importItem.id} />
-                      {importItem.status === ImportStatus.FAILED && (
-                        <Typography
-                          color="error"
-                          variant="body2"
-                          sx={{ mt: 2 }}
-                        >
-                          Error: {importItem.error}
-                        </Typography>
-                      )}
-                    </Box>
-                  </Collapse>
+                <td colSpan={9} style={{ padding: "2rem", textAlign: "center" }}>
+                  <Typography color="text.secondary">
+                    No imports match the selected filters.
+                  </Typography>
                 </td>
               </tr>
-            </React.Fragment>
-          ))}
-        </tbody>
-      </table>
-    </div>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {deleteDialog}
+    </>
   );
 }

--- a/src/hooks/useImports.ts
+++ b/src/hooks/useImports.ts
@@ -100,6 +100,17 @@ export const useMergeImportedTransactionMutation = (importId: string) => {
   });
 };
 
+export const useDeleteImportMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (importId: string) => importService.deleteImport(importId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["imports"] });
+    },
+  });
+};
+
 export const useDeleteImportedTransactionMutation = (importId: string) => {
   const queryClient = useQueryClient();
 

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -52,6 +52,10 @@ class ImportService {
     await api.post(`/api/imports/transactions/${transactionId}/ignore`);
   }
 
+  async deleteImport(importId: string): Promise<void> {
+    await api.delete(`/api/imports/${importId}`);
+  }
+
   async deleteImportedTransaction(transactionId: string): Promise<void> {
     await api.delete(`/api/imports/transactions/${transactionId}`);
   }

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -34,9 +34,17 @@ export async function getTransactionSummary(params?: {
   return res.data;
 }
 
+export interface CreateTransactionResponse {
+  id: string;
+  suggestedCategory?: {
+    id: string;
+    name: string;
+  };
+}
+
 export async function createTransaction(
   data: CreateTransactionInput
-): Promise<string> {
+): Promise<CreateTransactionResponse> {
   const res = await api.post("/api/transactions", data);
   return res.data;
 }


### PR DESCRIPTION
## Summary
- Persist active tab across page refreshes using URL hash
- Add MUI theme system with dark mode toggle and UI/UX improvements
- Fix dark mode: sync CSS vars with MUI theme and migrate to theme tokens
- **Add import list soft delete UI** with confirmation dialog on each row
- **Add client-side filtering** by status, payment month, and card last 4 digits
- **Add sortable column headers** (created at, payment month, status)
- Add `useDeleteImportMutation` hook for `DELETE /api/imports/:importId`
- Fix lint errors in CategoryConfirmationSnackbar and useTransactionsQuery

## Test plan
- [ ] Verify dark mode / light mode toggle works correctly
- [ ] Verify active tab persists across page refreshes
- [ ] Verify import list shows filter controls (status, payment month, card)
- [ ] Verify filters narrow down the import list
- [ ] Verify clicking column headers toggles sort direction
- [ ] Verify delete button shows confirmation dialog, then removes the import
- [ ] Verify mobile layout works for all new controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)