### PR TITLE
Add category confirmation UX for AI-categorized transactions

### DIFF
--- a/src/app/tabs/DashboardTab.tsx
+++ b/src/app/tabs/DashboardTab.tsx
@@ -36,8 +36,8 @@ export default function DashboardTab({
 
   const handleCreateSuccess = async (data: CreateTransactionInput) => {
     try {
-      const newId = await createMutation.mutateAsync(data);
-      return newId;
+      const result = await createMutation.mutateAsync(data);
+      return result.id;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create transaction");
     }

--- a/src/app/tabs/TransactionsTab.tsx
+++ b/src/app/tabs/TransactionsTab.tsx
@@ -22,6 +22,8 @@ import {
   useTransactionsSummaryQuery,
 } from "../../hooks/useTransactionsQuery";
 import IncomeExpensePieChart from "../../components/IncomeExpensePieChart";
+import CategoryConfirmationSnackbar from "../../components/CategoryConfirmationSnackbar";
+import { CreateTransactionResponse } from "../../services/transactions";
 import dayjs from "dayjs";
 
 function TransactionTableArea({
@@ -93,6 +95,11 @@ export default function TransactionsTab() {
     ...getDefaultFilters(),
   });
   const [error, setError] = useState<string | null>(null);
+  const [categoryConfirmation, setCategoryConfirmation] = useState<{
+    transactionId: string;
+    description: string;
+    suggestedCategory: { id: string; name: string };
+  } | null>(null);
 
   const { data: transactions = [], isLoading: loading } =
     useTransactionsQuery(filters);
@@ -126,8 +133,16 @@ export default function TransactionsTab() {
 
   const handleCreateSuccess = async (data: CreateTransactionInput) => {
     try {
-      const newId = await createMutation.mutateAsync(data);
-      return newId;
+      const result: CreateTransactionResponse =
+        await createMutation.mutateAsync(data);
+      if (result.suggestedCategory) {
+        setCategoryConfirmation({
+          transactionId: result.id,
+          description: data.description,
+          suggestedCategory: result.suggestedCategory,
+        });
+      }
+      return result.id;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create transaction");
     }
@@ -232,6 +247,16 @@ export default function TransactionsTab() {
         onApply={handleApplyFilters}
         initialFilters={filters}
       />
+
+      {categoryConfirmation && (
+        <CategoryConfirmationSnackbar
+          open={!!categoryConfirmation}
+          transactionId={categoryConfirmation.transactionId}
+          description={categoryConfirmation.description}
+          suggestedCategory={categoryConfirmation.suggestedCategory}
+          onClose={() => setCategoryConfirmation(null)}
+        />
+      )}
 
       <Snackbar
         open={!!error}

--- a/src/components/CategoryConfirmationSnackbar.tsx
+++ b/src/components/CategoryConfirmationSnackbar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Snackbar,
+  Alert,
+  Button,
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
+import CategorySelect from "./CategorySelect";
+import { useUpdateTransactionMutation } from "../hooks/useTransactionsQuery";
+import { UpdateTransactionInput } from "../types";
+
+interface CategoryConfirmationSnackbarProps {
+  open: boolean;
+  transactionId: string;
+  description: string;
+  suggestedCategory: { id: string; name: string };
+  onClose: () => void;
+}
+
+export default function CategoryConfirmationSnackbar({
+  open,
+  transactionId,
+  description,
+  suggestedCategory,
+  onClose,
+}: CategoryConfirmationSnackbarProps) {
+  const [changingCategory, setChangingCategory] = useState(false);
+  const [selectedCategoryId, setSelectedCategoryId] = useState(
+    suggestedCategory.id
+  );
+  const updateMutation = useUpdateTransactionMutation();
+
+  const handleChange = () => {
+    setSelectedCategoryId(suggestedCategory.id);
+    setChangingCategory(true);
+  };
+
+  const handleSave = async () => {
+    if (selectedCategoryId && selectedCategoryId !== suggestedCategory.id) {
+      await updateMutation.mutateAsync({
+        id: transactionId,
+        data: { categoryId: selectedCategoryId } as UpdateTransactionInput,
+      });
+    }
+    setChangingCategory(false);
+    onClose();
+  };
+
+  const handleDialogClose = () => {
+    setChangingCategory(false);
+  };
+
+  const truncatedDescription =
+    description.length > 30 ? description.slice(0, 30) + "..." : description;
+
+  return (
+    <>
+      <Snackbar
+        open={open && !changingCategory}
+        autoHideDuration={10000}
+        onClose={onClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          severity="info"
+          variant="filled"
+          onClose={onClose}
+          action={
+            <Button color="inherit" size="small" onClick={handleChange}>
+              Change
+            </Button>
+          }
+          sx={{ width: "100%", alignItems: "center" }}
+        >
+          <Typography variant="body2">
+            Category for &quot;{truncatedDescription}&quot;:{" "}
+            <strong>{suggestedCategory.name}</strong>
+          </Typography>
+        </Alert>
+      </Snackbar>
+
+      <Dialog
+        open={changingCategory}
+        onClose={handleDialogClose}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Change Category</DialogTitle>
+        <DialogContent>
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              &quot;{description}&quot;
+            </Typography>
+            <CategorySelect
+              value={selectedCategoryId}
+              onChange={setSelectedCategoryId}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDialogClose} variant="outlined">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            color="primary"
+            disabled={updateMutation.isPending}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -34,9 +34,17 @@ export async function getTransactionSummary(params?: {
   return res.data;
 }
 
+export interface CreateTransactionResponse {
+  id: string;
+  suggestedCategory?: {
+    id: string;
+    name: string;
+  };
+}
+
 export async function createTransaction(
   data: CreateTransactionInput
-): Promise<string> {
+): Promise<CreateTransactionResponse> {
   const res = await api.post("/api/transactions", data);
   return res.data;
 }


### PR DESCRIPTION
## Summary
- **CategoryConfirmationSnackbar**: New component that appears after creating a transaction without a category, showing the AI-suggested category with a "Change" button
- **Inline category correction**: Clicking "Change" opens a dialog with CategorySelect dropdown. Saving triggers the update mutation, which feeds into the backend's per-user learning system
- **Updated create response handling**: `createTransaction` now returns `{ id, suggestedCategory? }` from the API, enabling the frontend to show the confirmation UX

> **Depends on:** [API PR #10](https://github.com/yaniv120892/my-expenses/pull/10) — must be deployed first for the `suggestedCategory` field to be present in the response.

## Test plan
- [ ] Create a transaction without selecting a category → verify snackbar appears showing AI-suggested category
- [ ] Click "Change" → verify dialog opens with CategorySelect pre-filled
- [ ] Select a different category and save → verify transaction is updated
- [ ] Auto-dismiss: wait 10 seconds → verify snackbar disappears
- [ ] Create a transaction WITH a category → verify no snackbar appears
- [ ] Verify DashboardTab create transaction still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)