### PR TITLE
Fix mobile nav menu items hidden by purple overlay

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -198,7 +198,7 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
           <Box
             sx={{
               width: "100%",
-              height: 1,
+              height: "1px",
               bgcolor: "primary.main",
               margin: "2px 0 16px 0",
             }}


### PR DESCRIPTION
## Summary
- Fixed mobile sidebar navigation where only "Dashboard" was visible — all other menu items were covered by a purple overlay
- Root cause: MUI `sx` prop interprets `height: 1` as `height: '100%'` (not `1px`), causing the `primary.main` colored divider `Box` to fill the entire drawer
- Changed `height: 1` to `height: "1px"` in `Navbar.tsx`

## Test plan
- [ ] Open on mobile viewport (or Chrome DevTools responsive mode)
- [ ] Tap header to open sidebar drawer
- [ ] Confirm all menu items visible: Dashboard, Transactions, Pending, Scheduled, Imports, Trends, Settings
- [ ] Confirm thin purple divider line appears above Logout button
- [ ] Test both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)