### PR TITLE
Fix pre-existing build failures in next build

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import tseslint from "typescript-eslint";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,7 +11,8 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals"),
+  ...tseslint.configs.recommended,
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.817.0",
     "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^7.1.0",
-    "@mui/material": "^7.1.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.9",
+    "@mui/material": "^7.3.9",
+    "@mui/system": "^7.3.9",
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-query-devtools": "^5.0.0",
     "axios": "^1.9.0",
@@ -34,10 +35,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "husky": "^9.1.7",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "typescript-eslint": "^8.56.1"
   }
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, CircularProgress } from "@mui/material";
 
 export default function Loading() {


### PR DESCRIPTION
## Summary
- **ESLint fix**: Replaced `compat.extends("next/typescript")` with `typescript-eslint` v8 flat config to avoid npm workspace hoisting resolving the root's `@typescript-eslint` v6 (incompatible with ESLint 9)
- **MUI fix**: Added `"use client"` to `src/app/loading.tsx` which was a Server Component importing from `@mui/material` barrel — during SSR prerendering, this caused `unstable_createUseMediaQuery` to fail because `createProxy` doesn't implement the `ownKeys` Proxy trap
- Updated MUI packages to 7.3.9 and added explicit `@typescript-eslint` devDependencies

## Test plan
- [x] `npm run build` passes successfully with all 9 static pages generated
- [x] Pre-push hook (`next build`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)