### PR TITLE
Add subscription detection UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import PendingTransactionsTab from "./tabs/PendingTransactionsTab";
 import SettingsTab from "./tabs/SettingsTab";
 import TrendsTab from "./tabs/TrendsTab";
 import ImportsTab from "./tabs/ImportsTab";
+import SubscriptionsTab from "./tabs/SubscriptionsTab";
 import { Box, Fade } from "@mui/material";
 import { TabOption } from "../types";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -20,6 +21,7 @@ const tabToHash: Record<TabOption, string> = {
   [TabOption.Transactions]: "transactions",
   [TabOption.PendingTransactions]: "pending",
   [TabOption.ScheduledTransactions]: "scheduled",
+  [TabOption.Subscriptions]: "subscriptions",
   [TabOption.Settings]: "settings",
   [TabOption.Trends]: "trends",
   [TabOption.Imports]: "imports",
@@ -43,6 +45,7 @@ function getTabLabel(tab: TabOption) {
   if (tab === TabOption.Settings) return "Settings";
   if (tab === TabOption.Trends) return "Trends";
   if (tab === TabOption.Imports) return "Imports";
+  if (tab === TabOption.Subscriptions) return "Subscriptions";
   return "";
 }
 
@@ -79,8 +82,14 @@ export default function HomePage() {
             onNavigateToTransactions={() =>
               handleTabChange(TabOption.Transactions)
             }
+            onNavigateToSubscriptions={() =>
+              handleTabChange(TabOption.Subscriptions)
+            }
           />
         );
+      }
+      case TabOption.Subscriptions: {
+        return <SubscriptionsTab />;
       }
       case TabOption.ScheduledTransactions: {
         return <ScheduledTransactionsTab />;

--- a/src/app/tabs/DashboardTab.tsx
+++ b/src/app/tabs/DashboardTab.tsx
@@ -15,15 +15,18 @@ import { TopCategoriesChart } from "@/components/dashboard/TopCategoriesChart";
 import { MonthHighlights } from "@/components/dashboard/MonthHighlights";
 import { AiInsightsCard } from "@/components/dashboard/AiInsightsCard";
 import { RecentTransactionsQuickView } from "@/components/dashboard/RecentTransactionsQuickView";
+import { SubscriptionsCard } from "@/components/dashboard/SubscriptionsCard";
 import TransactionForm from "@/components/TransactionForm";
 import { CreateTransactionInput } from "@/types";
 
 interface DashboardTabProps {
   onNavigateToTransactions: () => void;
+  onNavigateToSubscriptions: () => void;
 }
 
 export default function DashboardTab({
   onNavigateToTransactions,
+  onNavigateToSubscriptions,
 }: DashboardTabProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -95,6 +98,13 @@ export default function DashboardTab({
             onViewAll={onNavigateToTransactions}
           />
         </Box>
+      </Box>
+
+      <Box sx={{ mt: 3 }}>
+        <SubscriptionsCard
+          subscriptions={data.subscriptions}
+          onViewAll={onNavigateToSubscriptions}
+        />
       </Box>
 
       <TransactionForm

--- a/src/app/tabs/SettingsTab.tsx
+++ b/src/app/tabs/SettingsTab.tsx
@@ -38,6 +38,7 @@ type UserSettingsForm = {
   notifications: {
     createTransaction: boolean;
     dailySummary: boolean;
+    subscriptionAudit: boolean;
   };
   info: {
     email: string;
@@ -59,7 +60,7 @@ export default function SettingsTab() {
   const { control, handleSubmit, reset, watch, formState } = useForm({
     defaultValues: {
       provider: { telegramChatId: "" },
-      notifications: { createTransaction: false, dailySummary: false },
+      notifications: { createTransaction: false, dailySummary: false, subscriptionAudit: false },
       info: { email: "" },
     },
     mode: "onChange",
@@ -141,6 +142,7 @@ export default function SettingsTab() {
       notifications: {
         createTransaction: data.notifications.createTransaction,
         dailySummary: data.notifications.dailySummary,
+        subscriptionAudit: data.notifications.subscriptionAudit,
       },
       info: {
         email: data.info.email,
@@ -392,6 +394,22 @@ export default function SettingsTab() {
                 />
               }
               label="Daily summary notification"
+            />
+          )}
+        />
+        <Controller
+          name="notifications.subscriptionAudit"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={field.value}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                  sx={{ color: "text.primary" }}
+                />
+              }
+              label="Monthly subscription audit"
             />
           )}
         />

--- a/src/app/tabs/SubscriptionsTab.tsx
+++ b/src/app/tabs/SubscriptionsTab.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  Tabs,
+  Tab,
+  Alert,
+  Skeleton,
+  Paper,
+} from "@mui/material";
+import {
+  useSubscriptionsQuery,
+  useConfirmSubscriptionMutation,
+  useDismissSubscriptionMutation,
+  useConvertSubscriptionMutation,
+} from "@/hooks/useSubscriptionsQuery";
+import SubscriptionCard from "@/components/subscriptions/SubscriptionCard";
+import ConvertToScheduledDialog from "@/components/subscriptions/ConvertToScheduledDialog";
+import { DetectedSubscription, SubscriptionStatus } from "@/types/subscription";
+
+type FilterTab = "ALL" | SubscriptionStatus;
+
+export default function SubscriptionsTab() {
+  const [filterTab, setFilterTab] = useState<FilterTab>("ALL");
+  const [convertTarget, setConvertTarget] =
+    useState<DetectedSubscription | null>(null);
+
+  const statusParam = filterTab === "ALL" ? undefined : filterTab;
+  const { data, isLoading, error } = useSubscriptionsQuery(statusParam);
+  const confirmMutation = useConfirmSubscriptionMutation();
+  const dismissMutation = useDismissSubscriptionMutation();
+  const convertMutation = useConvertSubscriptionMutation();
+
+  function handleConvert(id: string, categoryId: string) {
+    convertMutation.mutate(
+      { id, categoryId },
+      { onSuccess: () => setConvertTarget(null) }
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error">
+        {error instanceof Error ? error.message : "Failed to load subscriptions"}
+      </Alert>
+    );
+  }
+
+  return (
+    <Box sx={{ p: { xs: 1, md: 3 } }}>
+      <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
+        Subscriptions
+      </Typography>
+
+      {isLoading ? (
+        <Box>
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              variant="rounded"
+              height={120}
+              sx={{ mb: 2, borderRadius: 2 }}
+            />
+          ))}
+        </Box>
+      ) : (
+        data && (
+          <>
+            <Paper
+              sx={{
+                display: "flex",
+                gap: 3,
+                p: 2,
+                mb: 3,
+                borderRadius: 2,
+                boxShadow: 2,
+              }}
+            >
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Active
+                </Typography>
+                <Typography variant="h5" fontWeight={700}>
+                  {data.activeCount}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Detected
+                </Typography>
+                <Typography variant="h5" fontWeight={700} color="warning.main">
+                  {data.detectedCount}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Monthly
+                </Typography>
+                <Typography variant="h5" fontWeight={700}>
+                  ${data.totalMonthlyEstimate.toFixed(0)}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Annual
+                </Typography>
+                <Typography variant="h5" fontWeight={700}>
+                  ${data.totalAnnualEstimate.toFixed(0)}
+                </Typography>
+              </Box>
+            </Paper>
+
+            <Tabs
+              value={filterTab}
+              onChange={(_, v) => setFilterTab(v)}
+              sx={{ mb: 2 }}
+            >
+              <Tab label="All" value="ALL" />
+              <Tab label="Detected" value="DETECTED" />
+              <Tab label="Confirmed" value="CONFIRMED" />
+              <Tab label="Dismissed" value="DISMISSED" />
+            </Tabs>
+
+            {data.subscriptions.length === 0 ? (
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{ textAlign: "center", py: 4 }}
+              >
+                No subscriptions found
+              </Typography>
+            ) : (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {data.subscriptions.map((sub) => (
+                  <SubscriptionCard
+                    key={sub.id}
+                    subscription={sub}
+                    onConfirm={(id) => confirmMutation.mutate(id)}
+                    onDismiss={(id) => dismissMutation.mutate(id)}
+                    onConvert={setConvertTarget}
+                  />
+                ))}
+              </Box>
+            )}
+
+            <ConvertToScheduledDialog
+              open={!!convertTarget}
+              subscription={convertTarget}
+              onClose={() => setConvertTarget(null)}
+              onConvert={handleConvert}
+              isLoading={convertMutation.isPending}
+            />
+          </>
+        )
+      )}
+    </Box>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -180,6 +180,14 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
               )}
             />
             <Tab
+              label="Subscriptions"
+              value={TabOption.Subscriptions}
+              sx={getTabStyle(
+                activeTab === TabOption.Subscriptions,
+                isMobile
+              )}
+            />
+            <Tab
               label="Imports"
               value={TabOption.Imports}
               sx={getTabStyle(activeTab === TabOption.Imports, isMobile)}
@@ -263,6 +271,14 @@ const Navbar: React.FC<NavbarProps> = ({ activeTab, onTabChange }) => {
               value={TabOption.ScheduledTransactions}
               sx={getTabStyle(
                 activeTab === TabOption.ScheduledTransactions,
+                isMobile
+              )}
+            />
+            <Tab
+              label="Subscriptions"
+              value={TabOption.Subscriptions}
+              sx={getTabStyle(
+                activeTab === TabOption.Subscriptions,
                 isMobile
               )}
             />

--- a/src/components/dashboard/SubscriptionsCard.tsx
+++ b/src/components/dashboard/SubscriptionsCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Badge,
+} from "@mui/material";
+import RepeatIcon from "@mui/icons-material/Repeat";
+import { SubscriptionSnapshot } from "@/types/dashboard";
+
+interface Props {
+  subscriptions: SubscriptionSnapshot | undefined;
+  onViewAll: () => void;
+}
+
+export function SubscriptionsCard({ subscriptions, onViewAll }: Props) {
+  if (!subscriptions) return null;
+
+  const { activeCount, totalMonthlyEstimate, totalAnnualEstimate, detectedCount } = subscriptions;
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        bgcolor: "background.default",
+        boxShadow: 3,
+        height: "100%",
+      }}
+    >
+      <CardContent>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+          <RepeatIcon color="primary" />
+          <Typography variant="h6" fontWeight={700}>
+            Subscriptions
+          </Typography>
+          {detectedCount > 0 && (
+            <Badge badgeContent={detectedCount} color="error" sx={{ ml: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                new
+              </Typography>
+            </Badge>
+          )}
+        </Box>
+
+        <Box sx={{ display: "flex", gap: 3, mb: 2 }}>
+          <Box>
+            <Typography variant="body2" color="text.secondary">
+              Active
+            </Typography>
+            <Typography variant="h5" fontWeight={700}>
+              {activeCount}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" color="text.secondary">
+              Monthly
+            </Typography>
+            <Typography variant="h5" fontWeight={700}>
+              ${totalMonthlyEstimate.toFixed(0)}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" color="text.secondary">
+              Annual
+            </Typography>
+            <Typography variant="h5" fontWeight={700}>
+              ${totalAnnualEstimate.toFixed(0)}
+            </Typography>
+          </Box>
+        </Box>
+
+        <Button variant="outlined" size="small" onClick={onViewAll} fullWidth>
+          View all subscriptions
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/subscriptions/ConvertToScheduledDialog.tsx
+++ b/src/components/subscriptions/ConvertToScheduledDialog.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+} from "@mui/material";
+import CategorySelect from "@/components/CategorySelect";
+import { DetectedSubscription } from "@/types/subscription";
+
+interface Props {
+  open: boolean;
+  subscription: DetectedSubscription | null;
+  onClose: () => void;
+  onConvert: (id: string, categoryId: string) => void;
+  isLoading: boolean;
+}
+
+export default function ConvertToScheduledDialog({
+  open,
+  subscription,
+  onClose,
+  onConvert,
+  isLoading,
+}: Props) {
+  const [categoryId, setCategoryId] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setCategoryId("");
+    }
+  }, [open]);
+
+  function handleSubmit() {
+    if (!subscription || !categoryId) return;
+    onConvert(subscription.id, categoryId);
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Convert to Scheduled Transaction</DialogTitle>
+      <DialogContent>
+        {subscription && (
+          <>
+            <Box sx={{ mb: 2, mt: 1 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                Description
+              </Typography>
+              <Typography variant="body1" fontWeight={600}>
+                {subscription.displayName}
+              </Typography>
+            </Box>
+            <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  Amount
+                </Typography>
+                <Typography variant="body1" fontWeight={600}>
+                  ${subscription.averageAmount.toFixed(2)}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  Frequency
+                </Typography>
+                <Typography variant="body1" fontWeight={600}>
+                  {subscription.frequency}
+                </Typography>
+              </Box>
+            </Box>
+            <CategorySelect
+              value={categoryId}
+              onChange={setCategoryId}
+              required
+            />
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!categoryId || isLoading}
+        >
+          {isLoading ? "Converting..." : "Convert"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Chip,
+  Button,
+  LinearProgress,
+} from "@mui/material";
+import { DetectedSubscription } from "@/types/subscription";
+
+interface Props {
+  subscription: DetectedSubscription;
+  onConfirm: (id: string) => void;
+  onDismiss: (id: string) => void;
+  onConvert: (subscription: DetectedSubscription) => void;
+}
+
+function formatFrequency(frequency: string): string {
+  switch (frequency) {
+    case "WEEKLY":
+      return "Weekly";
+    case "MONTHLY":
+      return "Monthly";
+    case "YEARLY":
+      return "Yearly";
+    default:
+      return frequency;
+  }
+}
+
+function frequencyColor(
+  frequency: string
+): "primary" | "secondary" | "warning" {
+  switch (frequency) {
+    case "WEEKLY":
+      return "warning";
+    case "MONTHLY":
+      return "primary";
+    case "YEARLY":
+      return "secondary";
+    default:
+      return "primary";
+  }
+}
+
+function statusColor(
+  status: string
+): "default" | "success" | "warning" | "error" {
+  switch (status) {
+    case "DETECTED":
+      return "warning";
+    case "CONFIRMED":
+      return "success";
+    case "DISMISSED":
+      return "default";
+    default:
+      return "default";
+  }
+}
+
+export default function SubscriptionCard({
+  subscription,
+  onConfirm,
+  onDismiss,
+  onConvert,
+}: Props) {
+  const nextDate = new Date(subscription.nextExpectedDate).toLocaleDateString();
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 2,
+        boxShadow: 2,
+        bgcolor: "background.paper",
+      }}
+    >
+      <CardContent sx={{ pb: "16px !important" }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            mb: 1,
+          }}
+        >
+          <Box>
+            <Typography variant="subtitle1" fontWeight={700}>
+              {subscription.displayName}
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, mt: 0.5 }}>
+              <Chip
+                label={formatFrequency(subscription.frequency)}
+                color={frequencyColor(subscription.frequency)}
+                size="small"
+                variant="outlined"
+              />
+              <Chip
+                label={subscription.status}
+                color={statusColor(subscription.status)}
+                size="small"
+              />
+            </Box>
+          </Box>
+          <Box sx={{ textAlign: "right" }}>
+            <Typography variant="h6" fontWeight={700}>
+              ${subscription.averageAmount.toFixed(2)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              ${subscription.annualCost.toFixed(2)}/yr
+            </Typography>
+          </Box>
+        </Box>
+
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Next expected: {nextDate}
+        </Typography>
+
+        {subscription.status === "DETECTED" && (
+          <Box sx={{ mb: 1.5 }}>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                mb: 0.5,
+              }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                Confidence
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {Math.round(subscription.confidence * 100)}%
+              </Typography>
+            </Box>
+            <LinearProgress
+              variant="determinate"
+              value={subscription.confidence * 100}
+              sx={{ borderRadius: 1, height: 6 }}
+            />
+          </Box>
+        )}
+
+        {subscription.status !== "DISMISSED" && (
+          <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+            {subscription.status === "DETECTED" && (
+              <>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={() => onConfirm(subscription.id)}
+                >
+                  Confirm
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  size="small"
+                  onClick={() => onDismiss(subscription.id)}
+                >
+                  Dismiss
+                </Button>
+              </>
+            )}
+            {!subscription.scheduledTransactionId && (
+              <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                onClick={() => onConvert(subscription)}
+              >
+                Convert to Scheduled
+              </Button>
+            )}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useSubscriptionsQuery.ts
+++ b/src/hooks/useSubscriptionsQuery.ts
@@ -1,0 +1,57 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchSubscriptions,
+  confirmSubscription,
+  dismissSubscription,
+  convertToScheduled,
+} from "../services/subscriptionService";
+import { scheduledTransactionKeys } from "./useScheduledTransactionsQuery";
+
+export const subscriptionKeys = {
+  all: ["subscriptions"] as const,
+  list: (status?: string) => [...subscriptionKeys.all, "list", status] as const,
+};
+
+export const useSubscriptionsQuery = (status?: string) => {
+  return useQuery({
+    queryKey: subscriptionKeys.list(status),
+    queryFn: () => fetchSubscriptions(status),
+  });
+};
+
+export const useConfirmSubscriptionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => confirmSubscription(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: subscriptionKeys.all });
+    },
+  });
+};
+
+export const useDismissSubscriptionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => dismissSubscription(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: subscriptionKeys.all });
+    },
+  });
+};
+
+export const useConvertSubscriptionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, categoryId }: { id: string; categoryId: string }) =>
+      convertToScheduled(id, categoryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: subscriptionKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: scheduledTransactionKeys.all,
+      });
+    },
+  });
+};

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,0 +1,40 @@
+import api from "./api";
+import {
+  SubscriptionSummary,
+  DetectedSubscription,
+} from "../types/subscription";
+
+async function fetchSubscriptions(
+  status?: string
+): Promise<SubscriptionSummary> {
+  const params = status ? { status } : {};
+  const res = await api.get("/api/subscriptions", { params });
+  return res.data;
+}
+
+async function confirmSubscription(id: string): Promise<DetectedSubscription> {
+  const res = await api.patch(`/api/subscriptions/${id}/confirm`);
+  return res.data;
+}
+
+async function dismissSubscription(id: string): Promise<DetectedSubscription> {
+  const res = await api.patch(`/api/subscriptions/${id}/dismiss`);
+  return res.data;
+}
+
+async function convertToScheduled(
+  id: string,
+  categoryId: string
+): Promise<DetectedSubscription> {
+  const res = await api.post(`/api/subscriptions/${id}/convert`, {
+    categoryId,
+  });
+  return res.data;
+}
+
+export {
+  fetchSubscriptions,
+  confirmSubscription,
+  dismissSubscription,
+  convertToScheduled,
+};

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,7 +1,15 @@
+export interface SubscriptionSnapshot {
+  activeCount: number;
+  totalMonthlyEstimate: number;
+  totalAnnualEstimate: number;
+  detectedCount: number;
+}
+
 export interface DashboardResponse {
   monthComparison: MonthComparison;
   topCategories: TopCategory[];
   recentTransactions: RecentTransaction[];
+  subscriptions?: SubscriptionSnapshot;
 }
 
 export interface DashboardInsightsResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export enum TabOption {
   Transactions = "TRANSACTIONS",
   PendingTransactions = "PENDING_TRANSACTIONS",
   ScheduledTransactions = "SCHEDULED_TRANSACTIONS",
+  Subscriptions = "SUBSCRIPTIONS",
   Dashboard = "DASHBOARD",
   Settings = "SETTINGS",
   Trends = "TRENDS",
@@ -124,6 +125,7 @@ export interface UserSettings {
   notifications: {
     createTransaction: boolean;
     dailySummary: boolean;
+    subscriptionAudit: boolean;
   };
   provider: {
     enabled: boolean;

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -1,0 +1,25 @@
+export type SubscriptionFrequency = "WEEKLY" | "MONTHLY" | "YEARLY";
+export type SubscriptionStatus = "DETECTED" | "CONFIRMED" | "DISMISSED";
+
+export interface DetectedSubscription {
+  id: string;
+  merchantName: string;
+  displayName: string;
+  averageAmount: number;
+  frequency: SubscriptionFrequency;
+  lastChargeDate: string;
+  nextExpectedDate: string;
+  annualCost: number;
+  status: SubscriptionStatus;
+  matchingDescriptions: string[];
+  scheduledTransactionId?: string;
+  confidence: number;
+}
+
+export interface SubscriptionSummary {
+  totalMonthlyEstimate: number;
+  totalAnnualEstimate: number;
+  activeCount: number;
+  detectedCount: number;
+  subscriptions: DetectedSubscription[];
+}


### PR DESCRIPTION
## Summary
- **Subscriptions tab**: Full tab with status filter tabs (All/Detected/Confirmed/Dismissed), summary stats header (active, detected, monthly, annual costs), subscription card list
- **SubscriptionCard**: Displays merchant name, frequency chip, status chip, amount, annual cost, confidence bar (for detected), and action buttons (Confirm/Dismiss/Convert to Scheduled)
- **ConvertToScheduledDialog**: MUI Dialog with CategorySelect, pre-filled description/amount/frequency from subscription
- **Dashboard SubscriptionsCard**: Summary card showing active count, monthly/annual costs with detected badge, "View all" navigation
- **Settings**: Monthly subscription audit notification toggle in Notifications section
- **Navigation**: Subscriptions tab added to Navbar (mobile + desktop) and page routing with `#subscriptions` hash

Depends on API PR: https://github.com/yaniv120892/my-expenses/pull/13

## Test plan
- [ ] Navigate to Subscriptions tab — verify list renders with correct data
- [ ] Switch between filter tabs (All/Detected/Confirmed/Dismissed) — verify filtering works
- [ ] Click Confirm on a detected subscription — verify status updates
- [ ] Click Dismiss on a detected subscription — verify status updates
- [ ] Click "Convert to Scheduled" — verify dialog opens with pre-filled data, select category, submit
- [ ] Dashboard: verify SubscriptionsCard renders with correct summary, "View all" navigates to tab
- [ ] Settings: verify subscription audit toggle appears and saves
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)