### PR TITLE
Fix subscriptions mobile responsiveness

### DIFF
--- a/src/app/tabs/SubscriptionsTab.tsx
+++ b/src/app/tabs/SubscriptionsTab.tsx
@@ -71,14 +71,15 @@ export default function SubscriptionsTab() {
             <Paper
               sx={{
                 display: "flex",
-                gap: 3,
+                flexWrap: "wrap",
+                gap: { xs: 1.5, md: 3 },
                 p: 2,
                 mb: 3,
                 borderRadius: 2,
                 boxShadow: 2,
               }}
             >
-              <Box>
+              <Box sx={{ minWidth: 80 }}>
                 <Typography variant="body2" color="text.secondary">
                   Active
                 </Typography>
@@ -86,7 +87,7 @@ export default function SubscriptionsTab() {
                   {data.activeCount}
                 </Typography>
               </Box>
-              <Box>
+              <Box sx={{ minWidth: 80 }}>
                 <Typography variant="body2" color="text.secondary">
                   Detected
                 </Typography>
@@ -94,7 +95,7 @@ export default function SubscriptionsTab() {
                   {data.detectedCount}
                 </Typography>
               </Box>
-              <Box>
+              <Box sx={{ minWidth: 80 }}>
                 <Typography variant="body2" color="text.secondary">
                   Monthly
                 </Typography>
@@ -102,7 +103,7 @@ export default function SubscriptionsTab() {
                   ${data.totalMonthlyEstimate.toFixed(0)}
                 </Typography>
               </Box>
-              <Box>
+              <Box sx={{ minWidth: 80 }}>
                 <Typography variant="body2" color="text.secondary">
                   Annual
                 </Typography>
@@ -115,6 +116,8 @@ export default function SubscriptionsTab() {
             <Tabs
               value={filterTab}
               onChange={(_, v) => setFilterTab(v)}
+              variant="scrollable"
+              scrollButtons="auto"
               sx={{ mb: 2 }}
             >
               <Tab label="All" value="ALL" />

--- a/src/components/dashboard/SubscriptionsCard.tsx
+++ b/src/components/dashboard/SubscriptionsCard.tsx
@@ -46,8 +46,8 @@ export function SubscriptionsCard({ subscriptions, onViewAll }: Props) {
           )}
         </Box>
 
-        <Box sx={{ display: "flex", gap: 3, mb: 2 }}>
-          <Box>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: { xs: 1.5, md: 3 }, mb: 2 }}>
+          <Box sx={{ minWidth: 80 }}>
             <Typography variant="body2" color="text.secondary">
               Active
             </Typography>
@@ -55,7 +55,7 @@ export function SubscriptionsCard({ subscriptions, onViewAll }: Props) {
               {activeCount}
             </Typography>
           </Box>
-          <Box>
+          <Box sx={{ minWidth: 80 }}>
             <Typography variant="body2" color="text.secondary">
               Monthly
             </Typography>
@@ -63,7 +63,7 @@ export function SubscriptionsCard({ subscriptions, onViewAll }: Props) {
               ${totalMonthlyEstimate.toFixed(0)}
             </Typography>
           </Box>
-          <Box>
+          <Box sx={{ minWidth: 80 }}>
             <Typography variant="body2" color="text.secondary">
               Annual
             </Typography>

--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -144,7 +144,7 @@ export default function SubscriptionCard({
         )}
 
         {subscription.status !== "DISMISSED" && (
-          <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1 }}>
             {subscription.status === "DETECTED" && (
               <>
                 <Button


### PR DESCRIPTION
## Summary
- **Stats rows** (SubscriptionsTab + dashboard SubscriptionsCard): Added `flexWrap: "wrap"`, responsive gap (`xs: 1.5, md: 3`), and `minWidth: 80` on each stat box so they reflow into a 2×2 grid on narrow screens
- **Filter tabs** (SubscriptionsTab): Added `variant="scrollable"` and `scrollButtons="auto"` so tabs scroll horizontally instead of overflowing
- **Button row** (SubscriptionCard): Added `flexWrap: "wrap"` so action buttons wrap on very narrow screens

## Test plan
- [ ] Open dev server and resize to ~375px width in Chrome DevTools
- [ ] Verify stats wrap into 2×2 grid on both SubscriptionsTab and dashboard card
- [ ] Verify filter tabs are horizontally scrollable on mobile
- [ ] Verify action buttons (Confirm/Dismiss/Convert) wrap gracefully on narrow screens
- [ ] Confirm no regressions on desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)