### PR TITLE
Hide chat FAB when chat dialog is open

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -46,22 +46,24 @@ const Chat: React.FC = () => {
 
   return (
     <>
-      <Fab
-        color="secondary"
-        aria-label="chat"
-        onClick={handleOpen}
-        sx={{
-          position: "fixed",
-          bottom: 96,
-          right: 32,
-          display: "flex",
-          flexDirection: "row",
-          gap: 2,
-          zIndex: 2000,
-        }}
-      >
-        <ChatIcon />
-      </Fab>
+      {!isOpen && (
+        <Fab
+          color="secondary"
+          aria-label="chat"
+          onClick={handleOpen}
+          sx={{
+            position: "fixed",
+            bottom: 96,
+            right: 32,
+            display: "flex",
+            flexDirection: "row",
+            gap: 2,
+            zIndex: 2000,
+          }}
+        >
+          <ChatIcon />
+        </Fab>
+      )}
       <Dialog
         open={isOpen}
         onClose={handleClose}


### PR DESCRIPTION
## Summary
- Hide the chat floating action button (FAB) when the chat dialog is already open to reduce visual clutter
- Uses conditional rendering (`{!isOpen && ...}`) on the existing `isOpen` state

## Test plan
- [ ] Click the chat FAB → dialog opens, FAB disappears
- [ ] Close the dialog → FAB reappears
- [ ] Verify no layout shift when FAB appears/disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)