### PR TITLE
Fix mobile file upload failing from Google Drive

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -38,8 +38,13 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadComplete }) => {
         setIsUploading(true);
         setUploadProgress(0);
 
+        const arrayBuffer = await file.arrayBuffer();
+        const blob = new Blob([arrayBuffer], {
+          type: file.type || "application/octet-stream",
+        });
+
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", blob, file.name);
         formData.append("paymentMonth", paymentMonth);
 
         const { fileUrl } = await importUploadMutation.mutateAsync({

--- a/src/hooks/useImports.ts
+++ b/src/hooks/useImports.ts
@@ -246,7 +246,19 @@ export function useImportUploadMutation() {
           }
         };
         xhr.onerror = () => {
-          reject(new Error("Network error during upload"));
+          reject(
+            new Error(
+              `Network error during upload (readyState: ${xhr.readyState}, status: ${xhr.status})`
+            )
+          );
+        };
+        xhr.timeout = 120000;
+        xhr.ontimeout = () => {
+          reject(
+            new Error(
+              "Upload timed out — please check your connection and try again"
+            )
+          );
         };
         xhr.send(formData);
       });


### PR DESCRIPTION
## Summary
- **Fix**: Read file into memory (`arrayBuffer()`) before creating `FormData`, resolving Android `content://` URI streaming failures when selecting files from Google Drive
- **Improve**: Add XHR timeout (2min) and richer error messages with `readyState`/`status` for easier debugging
- **Handle**: Default MIME type fallback (`application/octet-stream`) for Android file pickers that return empty types

## Test plan
- [ ] On Android, open Imports tab → tap FAB → select a file from Google Drive → verify upload completes
- [ ] On desktop browser, upload a file normally → verify no regression
- [ ] Verify large files don't timeout within 2 minutes on reasonable connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)