### PR TITLE
feat: add verified filter toggle to imports tab

### DIFF
--- a/docs/superpowers/specs/2026-04-02-imports-verified-filter-design.md
+++ b/docs/superpowers/specs/2026-04-02-imports-verified-filter-design.md
@@ -1,0 +1,39 @@
+# Imports Tab — Verified Filter
+
+**Date:** 2026-04-02  
+**Status:** Approved
+
+## Context
+
+The Imports list already displays a `Verified` / `Not Verified` indicator (CheckCircle/Cancel icon) for each import row, but there is no way to filter by this field. Users want to quickly see only unverified imports (e.g., to act on them) or only verified ones (to confirm completion).
+
+## Design
+
+### Component Changed
+`my-expenses-website/src/components/ImportList.tsx` — the only file modified.
+
+### State
+Add `isVerifiedFilter: "ALL" | "true" | "false"` alongside the existing filter state (`statusFilter`, `paymentMonthFilter`, `cardFilter`). Default: `"ALL"`.
+
+### UI — ToggleButtonGroup
+A MUI `ToggleButtonGroup` (exclusive, small size) placed in the existing filter `Stack`, after the other filters:
+
+```
+[ All ]  [ Verified ]  [ Not Verified ]
+```
+
+On mobile the Stack already switches to column layout, so this stacks naturally.
+
+### Filtering Logic
+Add one condition to the existing `useMemo` filter chain:
+- `"ALL"` → no change
+- `"true"` → `import.isVerified === true`
+- `"false"` → `import.isVerified === false`
+
+## Verification
+1. Run `npm run dev:website` and navigate to the Imports tab
+2. Confirm the toggle appears in the filter bar
+3. Toggle to "Verified" — only verified imports shown
+4. Toggle to "Not Verified" — only unverified imports shown
+5. Toggle back to "All" — all imports shown
+6. Confirm it composes correctly with the other filters (status, month, card)

--- a/src/components/ImportList.tsx
+++ b/src/components/ImportList.tsx
@@ -18,6 +18,8 @@ import {
   Select,
   MenuItem,
   Stack,
+  ToggleButtonGroup,
+  ToggleButton,
 } from "@mui/material";
 import {
   KeyboardArrowDown,
@@ -211,6 +213,7 @@ export default function ImportList({
   const [statusFilter, setStatusFilter] = useState<string>("ALL");
   const [paymentMonthFilter, setPaymentMonthFilter] = useState<string>("ALL");
   const [cardFilter, setCardFilter] = useState<string>("ALL");
+  const [isVerifiedFilter, setIsVerifiedFilter] = useState<"ALL" | "true" | "false">("ALL");
 
   // Sort state
   const [sortField, setSortField] = useState<SortField>("createdAt");
@@ -243,6 +246,11 @@ export default function ImportList({
         imp.creditCardLastFourDigits !== cardFilter
       )
         return false;
+      if (
+        isVerifiedFilter !== "ALL" &&
+        imp.isVerified !== (isVerifiedFilter === "true")
+      )
+        return false;
       return true;
     });
 
@@ -264,7 +272,7 @@ export default function ImportList({
     });
 
     return result;
-  }, [imports, statusFilter, paymentMonthFilter, cardFilter, sortField, sortDirection]);
+  }, [imports, statusFilter, paymentMonthFilter, cardFilter, isVerifiedFilter, sortField, sortDirection]);
 
   const handleSortClick = (field: SortField) => {
     if (sortField === field) {
@@ -341,6 +349,18 @@ export default function ImportList({
           ))}
         </Select>
       </FormControl>
+      <ToggleButtonGroup
+        value={isVerifiedFilter}
+        exclusive
+        size="small"
+        onChange={(_, newValue) => {
+          if (newValue !== null) setIsVerifiedFilter(newValue);
+        }}
+      >
+        <ToggleButton value="ALL">All</ToggleButton>
+        <ToggleButton value="true">Verified</ToggleButton>
+        <ToggleButton value="false">Not Verified</ToggleButton>
+      </ToggleButtonGroup>
     </Stack>
   );
 


### PR DESCRIPTION
## Motivation

The imports list already shows a Verified/Not Verified indicator per row, but there was no way to filter by this field. Users need to quickly isolate unverified imports to act on them or confirmed verified ones.

## Implementation

Added a MUI `ToggleButtonGroup` (All / Verified / Not Verified) to the existing inline filter bar in `ImportList.tsx`. The toggle filters the already-loaded data client-side via the existing `useMemo` chain — consistent with how the Status, Payment Month, and Card filters work. No API changes needed.

Key decisions:
- Used `ToggleButtonGroup` instead of a `Select` for visual distinction and quick interaction
- Guard against MUI's deselect-to-null behavior: if `newValue` is `null`, the selection is preserved
- Filter state typed as `"ALL" | "true" | "false"` to align with the existing string-based filter pattern

## Test Plan

- [ ] Navigate to Imports tab and confirm toggle appears in filter bar
- [ ] Toggle to "Verified" — only verified imports shown
- [ ] Toggle to "Not Verified" — only unverified imports shown  
- [ ] Toggle back to "All" — all imports shown
- [ ] Confirm filter composes correctly with Status, Payment Month, and Card filters