### PR TITLE
Add approve option for matched imported transactions

### DIFF
--- a/src/components/ImportedTransactionList.tsx
+++ b/src/components/ImportedTransactionList.tsx
@@ -294,7 +294,7 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
                 <Stack direction="row" spacing={1} justifyContent="center">
                   {transaction.status === ImportedTransactionStatus.PENDING && (
                     <>
-                      {transaction.matchingTransaction ? (
+                      {transaction.matchingTransaction && (
                         <Button
                           variant="contained"
                           size="small"
@@ -311,24 +311,23 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
                         >
                           {isMobile ? <MergeIcon /> : "Merge"}
                         </Button>
-                      ) : (
-                        <Button
-                          variant="contained"
-                          size="small"
-                          color="success"
-                          onClick={() => handleApprove(transaction.id)}
-                          disabled={!!pendingOperations[transaction.id]}
-                          startIcon={!isMobile && <CheckIcon />}
-                          sx={{
-                            textTransform: "none",
-                            fontWeight: 700,
-                            minWidth: isMobile ? 40 : 80,
-                            p: isMobile ? 1 : undefined,
-                          }}
-                        >
-                          {isMobile ? <CheckIcon /> : "Approve"}
-                        </Button>
                       )}
+                      <Button
+                        variant="contained"
+                        size="small"
+                        color="success"
+                        onClick={() => handleApprove(transaction.id)}
+                        disabled={!!pendingOperations[transaction.id]}
+                        startIcon={!isMobile && <CheckIcon />}
+                        sx={{
+                          textTransform: "none",
+                          fontWeight: 700,
+                          minWidth: isMobile ? 40 : 80,
+                          p: isMobile ? 1 : undefined,
+                        }}
+                      >
+                        {isMobile ? <CheckIcon /> : "Approve"}
+                      </Button>
                       <Button
                         variant="contained"
                         size="small"


### PR DESCRIPTION
## Summary
- When an imported transaction has a matching transaction, the UI now shows three action buttons (Merge / Approve / Ignore) instead of just (Merge / Ignore)
- This lets users reject false-positive matches and create new transactions instead of being forced to merge or ignore

## Test plan
- [ ] Verify matched imported transactions show all three buttons: Merge, Approve, Ignore
- [ ] Verify unmatched imported transactions still show only Approve and Ignore
- [ ] Verify Approve button works correctly for matched transactions (creates new transaction instead of merging)
- [ ] Verify mobile layout renders correctly with three buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)