### PR TITLE
feat: show schedule icon for pending scheduled transaction matches

### DIFF
--- a/src/components/ImportedTransactionList.tsx
+++ b/src/components/ImportedTransactionList.tsx
@@ -12,10 +12,12 @@ import {
   Chip,
   CircularProgress,
   Stack,
+  Tooltip,
   useTheme,
   useMediaQuery,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import EventRepeatIcon from "@mui/icons-material/EventRepeat";
 import MergeIcon from "@mui/icons-material/MergeType";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
@@ -31,6 +33,7 @@ import { formatDate } from "../utils/dateUtils";
 import {
   ImportedTransactionStatus,
   ImportedTransaction,
+  TransactionApprovalStatus,
 } from "../types/import";
 import TransactionForm from "./TransactionForm";
 import BatchActionToolbar from "./BatchActionToolbar";
@@ -268,9 +271,20 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
               <TableCell>
                 {transaction.matchingTransaction ? (
                   <Box>
-                    <Typography variant="body2">
-                      {transaction.matchingTransaction.description}
-                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <Typography variant="body2">
+                        {transaction.matchingTransaction.description}
+                      </Typography>
+                      {transaction.matchingTransaction.status ===
+                        TransactionApprovalStatus.PENDING_APPROVAL && (
+                        <Tooltip title="From scheduled transaction">
+                          <EventRepeatIcon
+                            fontSize="small"
+                            color="info"
+                          />
+                        </Tooltip>
+                      )}
+                    </Box>
                     <Typography variant="caption" color="var(--text-color)">
                       {formatAmount(transaction.matchingTransaction.value)} on{" "}
                       {formatDate(transaction.matchingTransaction.date)}{" "}

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -1,5 +1,10 @@
 import { TransactionType } from "./index";
 
+export enum TransactionApprovalStatus {
+  PENDING_APPROVAL = "PENDING_APPROVAL",
+  APPROVED = "APPROVED",
+}
+
 export enum ImportFileType {
   VISA_CREDIT = "VISA_CREDIT",
   MASTERCARD_CREDIT = "MASTERCARD_CREDIT",
@@ -47,7 +52,7 @@ export interface MatchingTransaction {
   date: string;
   categoryId: string;
   type: TransactionType;
-  status: ImportedTransactionStatus;
+  status: TransactionApprovalStatus;
   userId: string;
 }
 


### PR DESCRIPTION
## Summary
- Show an `EventRepeat` icon with tooltip "From scheduled transaction" next to matching transactions that have `PENDING_APPROVAL` status (generated by scheduled transaction processing)
- Fix `MatchingTransaction.status` type from `ImportedTransactionStatus` to new `TransactionApprovalStatus` enum — these are different domain concepts

## Changes
- `ImportedTransactionList.tsx`: Added `Tooltip` + `EventRepeatIcon` in matching transaction column, conditionally rendered when status is `PENDING_APPROVAL`
- `types/import.ts`: Added `TransactionApprovalStatus` enum, updated `MatchingTransaction.status` type

## Related
- API PR: https://github.com/yaniv120892/my-expenses/pull/17

## Test plan
- [ ] Import a file with transactions matching pending scheduled transactions
- [ ] Verify the schedule icon appears next to matching transaction descriptions for `PENDING_APPROVAL` matches
- [ ] Verify the tooltip shows "From scheduled transaction" on hover
- [ ] Verify no icon appears for regular `APPROVED` matches
- [ ] Verify merge/approve/ignore buttons still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)