### PR TITLE
feat: add REMATCHING status to frontend

### DIFF
--- a/src/components/ImportList.tsx
+++ b/src/components/ImportList.tsx
@@ -49,6 +49,7 @@ function getStatusColor(status: ImportStatus) {
     case ImportStatus.FAILED:
       return "error";
     case ImportStatus.PROCESSING:
+    case ImportStatus.REMATCHING:
       return "primary";
     default:
       return "default";

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -16,6 +16,7 @@ export enum ImportStatus {
   PROCESSING = "PROCESSING",
   COMPLETED = "COMPLETED",
   FAILED = "FAILED",
+  REMATCHING = "REMATCHING",
 }
 
 export enum ImportedTransactionStatus {


### PR DESCRIPTION
## Summary
- Add `REMATCHING` to `ImportStatus` enum in frontend types
- Add `REMATCHING` case to `getStatusColor()` in `ImportList.tsx` (renders as blue "primary" chip, same as PROCESSING)

**Depends on:** yaniv120892/my-expenses#9 (API PR)

## Test plan
- [ ] Verify REMATCHING status renders as a blue chip in the import list
- [ ] Verify Re-match button hides when import status is REMATCHING
- [ ] Verify REMATCHING appears in the status filter dropdown
- [ ] Verify build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)