### PR TITLE
feat: add status filter and income/expense sections to imported transactions

### DIFF
--- a/src/components/ImportedTransactionList.tsx
+++ b/src/components/ImportedTransactionList.tsx
@@ -15,6 +15,10 @@ import {
   Tooltip,
   useTheme,
   useMediaQuery,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EventRepeatIcon from "@mui/icons-material/EventRepeat";
@@ -38,6 +42,7 @@ import {
 import TransactionForm from "./TransactionForm";
 import BatchActionToolbar from "./BatchActionToolbar";
 import { CreateTransactionInput } from "../types";
+import { COLORS } from "../utils/constants";
 
 interface ImportedTransactionListProps {
   importId: string;
@@ -63,6 +68,7 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
   >({});
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const { data: autoApproveRules = [] } = useAutoApproveRulesQuery();
+  const [statusFilter, setStatusFilter] = useState<string>("ALL");
 
   const formatAmount = (value: number) => {
     return new Intl.NumberFormat("he-IL", {
@@ -75,6 +81,13 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
     () => transactions.filter((t) => !t.deleted),
     [transactions]
   );
+  const filteredTransactions = useMemo(
+    () =>
+      statusFilter === "ALL"
+        ? activeTransactions
+        : activeTransactions.filter((t) => t.status === statusFilter),
+    [activeTransactions, statusFilter]
+  );
   const pendingTransactions = useMemo(
     () =>
       activeTransactions.filter(
@@ -82,9 +95,24 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
       ),
     [activeTransactions]
   );
+  const visiblePendingTransactions = useMemo(
+    () =>
+      filteredTransactions.filter(
+        (t) => t.status === ImportedTransactionStatus.PENDING
+      ),
+    [filteredTransactions]
+  );
+  const expenseTransactions = useMemo(
+    () => filteredTransactions.filter((t) => t.type === "EXPENSE"),
+    [filteredTransactions]
+  );
+  const incomeTransactions = useMemo(
+    () => filteredTransactions.filter((t) => t.type === "INCOME"),
+    [filteredTransactions]
+  );
 
   const handleSelectAll = () => {
-    setSelectedIds(new Set(pendingTransactions.map((t) => t.id)));
+    setSelectedIds(new Set(visiblePendingTransactions.map((t) => t.id)));
   };
 
   const handleClearSelection = () => {
@@ -221,6 +249,23 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
         onClearSelection={handleClearSelection}
         hasAutoApproveRules={autoApproveRules.length > 0}
       />
+      <Box sx={{ mb: 2, px: 1, display: "flex", gap: 1.5, alignItems: "center" }}>
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Status</InputLabel>
+          <Select
+            value={statusFilter}
+            label="Status"
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <MenuItem value="ALL">All</MenuItem>
+            {Object.values(ImportedTransactionStatus).map((s) => (
+              <MenuItem key={s} value={s}>
+                {s}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
       <Table size="small">
         <TableHead>
           <TableRow>
@@ -228,11 +273,11 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
               <Checkbox
                 indeterminate={
                   selectedIds.size > 0 &&
-                  selectedIds.size < pendingTransactions.length
+                  selectedIds.size < visiblePendingTransactions.length
                 }
                 checked={
-                  pendingTransactions.length > 0 &&
-                  selectedIds.size === pendingTransactions.length
+                  visiblePendingTransactions.length > 0 &&
+                  selectedIds.size === visiblePendingTransactions.length
                 }
                 onChange={(e) =>
                   e.target.checked ? handleSelectAll() : handleClearSelection()
@@ -246,76 +291,153 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {activeTransactions.map((transaction) => (
-            <TableRow key={transaction.id} selected={selectedIds.has(transaction.id)}>
-              <TableCell padding="checkbox">
-                {transaction.status === ImportedTransactionStatus.PENDING ? (
-                  <Checkbox
-                    checked={selectedIds.has(transaction.id)}
-                    onChange={() => handleToggleSelect(transaction.id)}
-                  />
-                ) : null}
+          {expenseTransactions.length === 0 && incomeTransactions.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
+                <Typography color="var(--text-color)">
+                  No transactions match the selected filter.
+                </Typography>
               </TableCell>
-              <TableCell>
-                <Box>
-                  <Typography variant="body2">
-                    {transaction.description}
-                  </Typography>
-                  <Typography variant="caption" color="var(--text-color)">
-                    {formatAmount(transaction.value)} on{" "}
-                    {formatDate(transaction.date)} {transaction.type}
-                  </Typography>
-                </Box>
-              </TableCell>
-
-              <TableCell>
-                {transaction.matchingTransaction ? (
-                  <Box>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            </TableRow>
+          )}
+          {expenseTransactions.length > 0 && (
+            <>
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  sx={{
+                    backgroundColor: `${COLORS.expense}18`,
+                    borderLeft: `4px solid ${COLORS.expense}`,
+                    fontWeight: 700,
+                    fontSize: "0.95rem",
+                    py: 1,
+                    px: 2,
+                  }}
+                >
+                  Expenses ({expenseTransactions.length})
+                </TableCell>
+              </TableRow>
+              {expenseTransactions.map((transaction) => (
+                <TableRow key={transaction.id} selected={selectedIds.has(transaction.id)}>
+                  <TableCell padding="checkbox">
+                    {transaction.status === ImportedTransactionStatus.PENDING ? (
+                      <Checkbox
+                        checked={selectedIds.has(transaction.id)}
+                        onChange={() => handleToggleSelect(transaction.id)}
+                      />
+                    ) : null}
+                  </TableCell>
+                  <TableCell>
+                    <Box>
                       <Typography variant="body2">
-                        {transaction.matchingTransaction.description}
+                        {transaction.description}
                       </Typography>
-                      {transaction.matchingTransaction.status ===
-                        TransactionApprovalStatus.PENDING_APPROVAL && (
-                        <Tooltip title="From scheduled transaction">
-                          <EventRepeatIcon
-                            fontSize="small"
-                            color="info"
-                          />
-                        </Tooltip>
-                      )}
+                      <Typography variant="caption" color="var(--text-color)">
+                        {formatAmount(transaction.value)} on{" "}
+                        {formatDate(transaction.date)} {transaction.type}
+                      </Typography>
                     </Box>
-                    <Typography variant="caption" color="var(--text-color)">
-                      {formatAmount(transaction.matchingTransaction.value)} on{" "}
-                      {formatDate(transaction.matchingTransaction.date)}{" "}
-                      {transaction.matchingTransaction.type}
-                    </Typography>
-                  </Box>
-                ) : (
-                  <Typography variant="body2" color="var(--text-color)">
-                    No match found
-                  </Typography>
-                )}
-              </TableCell>
-              <TableCell>
-                <Chip
-                  label={transaction.status}
-                  color={getStatusColor(transaction.status)}
-                  size="small"
-                />
-              </TableCell>
-              <TableCell>
-                <Stack direction="row" spacing={1} justifyContent="center">
-                  {transaction.status === ImportedTransactionStatus.PENDING && (
-                    <>
-                      {transaction.matchingTransaction && (
+                  </TableCell>
+                  <TableCell>
+                    {transaction.matchingTransaction ? (
+                      <Box>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <Typography variant="body2">
+                            {transaction.matchingTransaction.description}
+                          </Typography>
+                          {transaction.matchingTransaction.status ===
+                            TransactionApprovalStatus.PENDING_APPROVAL && (
+                            <Tooltip title="From scheduled transaction">
+                              <EventRepeatIcon
+                                fontSize="small"
+                                color="info"
+                              />
+                            </Tooltip>
+                          )}
+                        </Box>
+                        <Typography variant="caption" color="var(--text-color)">
+                          {formatAmount(transaction.matchingTransaction.value)} on{" "}
+                          {formatDate(transaction.matchingTransaction.date)}{" "}
+                          {transaction.matchingTransaction.type}
+                        </Typography>
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="var(--text-color)">
+                        No match found
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={transaction.status}
+                      color={getStatusColor(transaction.status)}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={1} justifyContent="center">
+                      {transaction.status === ImportedTransactionStatus.PENDING && (
+                        <>
+                          {transaction.matchingTransaction && (
+                            <Button
+                              variant="contained"
+                              size="small"
+                              color="info"
+                              onClick={() => handleMerge(transaction.id)}
+                              disabled={!!pendingOperations[transaction.id]}
+                              startIcon={!isMobile && <MergeIcon />}
+                              sx={{
+                                textTransform: "none",
+                                fontWeight: 700,
+                                minWidth: isMobile ? 40 : 80,
+                                p: isMobile ? 1 : undefined,
+                              }}
+                            >
+                              {isMobile ? <MergeIcon /> : "Merge"}
+                            </Button>
+                          )}
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="success"
+                            onClick={() => handleApprove(transaction.id)}
+                            disabled={!!pendingOperations[transaction.id]}
+                            startIcon={!isMobile && <CheckIcon />}
+                            sx={{
+                              textTransform: "none",
+                              fontWeight: 700,
+                              minWidth: isMobile ? 40 : 80,
+                              p: isMobile ? 1 : undefined,
+                            }}
+                          >
+                            {isMobile ? <CheckIcon /> : "Approve"}
+                          </Button>
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="warning"
+                            onClick={() => handleIgnore(transaction.id)}
+                            disabled={!!pendingOperations[transaction.id]}
+                            startIcon={!isMobile && <CloseIcon />}
+                            sx={{
+                              textTransform: "none",
+                              fontWeight: 700,
+                              minWidth: isMobile ? 40 : 80,
+                              p: isMobile ? 1 : undefined,
+                            }}
+                          >
+                            {isMobile ? <CloseIcon /> : "Ignore"}
+                          </Button>
+                        </>
+                      )}
+                      {transaction.status !== ImportedTransactionStatus.PENDING && (
                         <Button
                           variant="contained"
                           size="small"
-                          color="info"
-                          onClick={() => handleMerge(transaction.id)}
+                          color="error"
+                          onClick={() => handleDelete(transaction.id)}
                           disabled={!!pendingOperations[transaction.id]}
-                          startIcon={!isMobile && <MergeIcon />}
+                          startIcon={!isMobile && <DeleteIcon />}
                           sx={{
                             textTransform: "none",
                             fontWeight: 700,
@@ -323,65 +445,169 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
                             p: isMobile ? 1 : undefined,
                           }}
                         >
-                          {isMobile ? <MergeIcon /> : "Merge"}
+                          {isMobile ? <DeleteIcon /> : "Delete"}
                         </Button>
                       )}
-                      <Button
-                        variant="contained"
-                        size="small"
-                        color="success"
-                        onClick={() => handleApprove(transaction.id)}
-                        disabled={!!pendingOperations[transaction.id]}
-                        startIcon={!isMobile && <CheckIcon />}
-                        sx={{
-                          textTransform: "none",
-                          fontWeight: 700,
-                          minWidth: isMobile ? 40 : 80,
-                          p: isMobile ? 1 : undefined,
-                        }}
-                      >
-                        {isMobile ? <CheckIcon /> : "Approve"}
-                      </Button>
-                      <Button
-                        variant="contained"
-                        size="small"
-                        color="warning"
-                        onClick={() => handleIgnore(transaction.id)}
-                        disabled={!!pendingOperations[transaction.id]}
-                        startIcon={!isMobile && <CloseIcon />}
-                        sx={{
-                          textTransform: "none",
-                          fontWeight: 700,
-                          minWidth: isMobile ? 40 : 80,
-                          p: isMobile ? 1 : undefined,
-                        }}
-                      >
-                        {isMobile ? <CloseIcon /> : "Ignore"}
-                      </Button>
-                    </>
-                  )}
-                  {transaction.status !== ImportedTransactionStatus.PENDING && (
-                    <Button
-                      variant="contained"
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </>
+          )}
+          {incomeTransactions.length > 0 && (
+            <>
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  sx={{
+                    backgroundColor: `${COLORS.income}18`,
+                    borderLeft: `4px solid ${COLORS.income}`,
+                    fontWeight: 700,
+                    fontSize: "0.95rem",
+                    py: 1,
+                    px: 2,
+                  }}
+                >
+                  Incomes ({incomeTransactions.length})
+                </TableCell>
+              </TableRow>
+              {incomeTransactions.map((transaction) => (
+                <TableRow key={transaction.id} selected={selectedIds.has(transaction.id)}>
+                  <TableCell padding="checkbox">
+                    {transaction.status === ImportedTransactionStatus.PENDING ? (
+                      <Checkbox
+                        checked={selectedIds.has(transaction.id)}
+                        onChange={() => handleToggleSelect(transaction.id)}
+                      />
+                    ) : null}
+                  </TableCell>
+                  <TableCell>
+                    <Box>
+                      <Typography variant="body2">
+                        {transaction.description}
+                      </Typography>
+                      <Typography variant="caption" color="var(--text-color)">
+                        {formatAmount(transaction.value)} on{" "}
+                        {formatDate(transaction.date)} {transaction.type}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    {transaction.matchingTransaction ? (
+                      <Box>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <Typography variant="body2">
+                            {transaction.matchingTransaction.description}
+                          </Typography>
+                          {transaction.matchingTransaction.status ===
+                            TransactionApprovalStatus.PENDING_APPROVAL && (
+                            <Tooltip title="From scheduled transaction">
+                              <EventRepeatIcon
+                                fontSize="small"
+                                color="info"
+                              />
+                            </Tooltip>
+                          )}
+                        </Box>
+                        <Typography variant="caption" color="var(--text-color)">
+                          {formatAmount(transaction.matchingTransaction.value)} on{" "}
+                          {formatDate(transaction.matchingTransaction.date)}{" "}
+                          {transaction.matchingTransaction.type}
+                        </Typography>
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="var(--text-color)">
+                        No match found
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={transaction.status}
+                      color={getStatusColor(transaction.status)}
                       size="small"
-                      color="error"
-                      onClick={() => handleDelete(transaction.id)}
-                      disabled={!!pendingOperations[transaction.id]}
-                      startIcon={!isMobile && <DeleteIcon />}
-                      sx={{
-                        textTransform: "none",
-                        fontWeight: 700,
-                        minWidth: isMobile ? 40 : 80,
-                        p: isMobile ? 1 : undefined,
-                      }}
-                    >
-                      {isMobile ? <DeleteIcon /> : "Delete"}
-                    </Button>
-                  )}
-                </Stack>
-              </TableCell>
-            </TableRow>
-          ))}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={1} justifyContent="center">
+                      {transaction.status === ImportedTransactionStatus.PENDING && (
+                        <>
+                          {transaction.matchingTransaction && (
+                            <Button
+                              variant="contained"
+                              size="small"
+                              color="info"
+                              onClick={() => handleMerge(transaction.id)}
+                              disabled={!!pendingOperations[transaction.id]}
+                              startIcon={!isMobile && <MergeIcon />}
+                              sx={{
+                                textTransform: "none",
+                                fontWeight: 700,
+                                minWidth: isMobile ? 40 : 80,
+                                p: isMobile ? 1 : undefined,
+                              }}
+                            >
+                              {isMobile ? <MergeIcon /> : "Merge"}
+                            </Button>
+                          )}
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="success"
+                            onClick={() => handleApprove(transaction.id)}
+                            disabled={!!pendingOperations[transaction.id]}
+                            startIcon={!isMobile && <CheckIcon />}
+                            sx={{
+                              textTransform: "none",
+                              fontWeight: 700,
+                              minWidth: isMobile ? 40 : 80,
+                              p: isMobile ? 1 : undefined,
+                            }}
+                          >
+                            {isMobile ? <CheckIcon /> : "Approve"}
+                          </Button>
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="warning"
+                            onClick={() => handleIgnore(transaction.id)}
+                            disabled={!!pendingOperations[transaction.id]}
+                            startIcon={!isMobile && <CloseIcon />}
+                            sx={{
+                              textTransform: "none",
+                              fontWeight: 700,
+                              minWidth: isMobile ? 40 : 80,
+                              p: isMobile ? 1 : undefined,
+                            }}
+                          >
+                            {isMobile ? <CloseIcon /> : "Ignore"}
+                          </Button>
+                        </>
+                      )}
+                      {transaction.status !== ImportedTransactionStatus.PENDING && (
+                        <Button
+                          variant="contained"
+                          size="small"
+                          color="error"
+                          onClick={() => handleDelete(transaction.id)}
+                          disabled={!!pendingOperations[transaction.id]}
+                          startIcon={!isMobile && <DeleteIcon />}
+                          sx={{
+                            textTransform: "none",
+                            fontWeight: 700,
+                            minWidth: isMobile ? 40 : 80,
+                            p: isMobile ? 1 : undefined,
+                          }}
+                        >
+                          {isMobile ? <DeleteIcon /> : "Delete"}
+                        </Button>
+                      )}
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </>
+          )}
         </TableBody>
       </Table>
       <TransactionForm


### PR DESCRIPTION
## Summary
- Add a frontend-only status filter dropdown (PENDING/APPROVED/MERGED/IGNORED) to the imported transactions list
- Split imported transactions into two color-coded sections: Expenses (red accent) and Incomes (green accent) with item counts
- Checkbox select-all correctly scopes to visible pending transactions when a filter is active
- BatchActionToolbar pending count remains based on unfiltered data so batch operations are unaffected

## Test plan
- [ ] Expand an import with mixed income/expense transactions — verify two sections appear with correct color accents
- [ ] Use the status filter dropdown to select PENDING — verify only pending transactions shown, in both sections
- [ ] Verify BatchActionToolbar pending count doesn't change when filter changes
- [ ] Verify "Select All" checkbox only selects visible pending transactions
- [ ] Verify empty filter result shows "No transactions match the selected filter" message
- [ ] Test on mobile breakpoint — filter dropdown and sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)