### PR TITLE
feat: default filters to PENDING and Not Verified

### DIFF
--- a/src/components/ImportList.tsx
+++ b/src/components/ImportList.tsx
@@ -253,7 +253,7 @@ export default function ImportList({
   const [statusFilter, setStatusFilter] = useState<string>("ALL");
   const [paymentMonthFilter, setPaymentMonthFilter] = useState<string>("ALL");
   const [cardFilter, setCardFilter] = useState<string>("ALL");
-  const [isVerifiedFilter, setIsVerifiedFilter] = useState<"ALL" | "true" | "false">("ALL");
+  const [isVerifiedFilter, setIsVerifiedFilter] = useState<"ALL" | "true" | "false">("false");
 
   // Sort state
   const [sortField, setSortField] = useState<SortField>("createdAt");

--- a/src/components/ImportedTransactionList.tsx
+++ b/src/components/ImportedTransactionList.tsx
@@ -68,7 +68,7 @@ const ImportedTransactionList: React.FC<ImportedTransactionListProps> = ({
   >({});
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const { data: autoApproveRules = [] } = useAutoApproveRulesQuery();
-  const [statusFilter, setStatusFilter] = useState<string>("ALL");
+  const [statusFilter, setStatusFilter] = useState<string>(ImportedTransactionStatus.PENDING);
 
   const formatAmount = (value: number) => {
     return new Intl.NumberFormat("he-IL", {


### PR DESCRIPTION
## Summary
- Default imported transactions status filter to **PENDING** instead of All
- Default import list verified filter to **Not Verified** instead of All
- Users see the most actionable items first without needing to manually adjust filters

## Test plan
- [ ] Open Imports tab — verify imports show only "Not Verified" by default
- [ ] Expand an import — verify only PENDING transactions are shown by default
- [ ] Change filters to other values — verify they still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)